### PR TITLE
sarkars/Make VLOG=1 to avoid multiple prints in gtests

### DIFF
--- a/src/enable_variable_ops/ngraph_rewrite_pass.cc
+++ b/src/enable_variable_ops/ngraph_rewrite_pass.cc
@@ -169,7 +169,7 @@ class NGraphVariableCapturePass : public NGraphRewritePass {
         (!config::IsEnabled()) || (std::getenv("NGRAPH_TF_DISABLE") != nullptr);
     bool already_processed = IsProcessedByNgraphPass(options.graph->get());
     if (ngraph_not_enabled || already_processed) {
-      NGRAPH_VLOG(0) << "Not running through nGraph. nGraph not enabled: "
+      NGRAPH_VLOG(1) << "Not running through nGraph. nGraph not enabled: "
                      << ngraph_not_enabled
                      << " Already processed: " << already_processed;
       NGraphClusterManager::EvictAllClusters();
@@ -244,7 +244,7 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
         (!config::IsEnabled()) || (std::getenv("NGRAPH_TF_DISABLE") != nullptr);
     bool already_processed = IsProcessedByNgraphPass(options.graph->get());
     if (ngraph_not_enabled || already_processed) {
-      NGRAPH_VLOG(0) << "Not running through nGraph. nGraph not enabled: "
+      NGRAPH_VLOG(1) << "Not running through nGraph. nGraph not enabled: "
                      << ngraph_not_enabled
                      << " Already processed: " << already_processed;
       NGraphClusterManager::EvictAllClusters();

--- a/src/ngraph_rewrite_pass.cc
+++ b/src/ngraph_rewrite_pass.cc
@@ -137,7 +137,7 @@ class NGraphVariableCapturePass : public NGraphRewritePass {
       // cluster manager is not overwritten. Which would mean that cluster
       // manager contains stale data from a previous run. Hence evicting cluster
       // manager when rewrite passes are not run.
-      NGRAPH_VLOG(0) << "Not running through nGraph. nGraph not enabled: "
+      NGRAPH_VLOG(1) << "Not running through nGraph. nGraph not enabled: "
                      << ngraph_not_enabled
                      << " Already processed: " << already_processed;
       NGraphClusterManager::EvictAllClusters();
@@ -202,7 +202,7 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
         (!config::IsEnabled()) || (std::getenv("NGRAPH_TF_DISABLE") != nullptr);
     bool already_processed = IsProcessedByNgraphPass(options.graph->get());
     if (ngraph_not_enabled || already_processed) {
-      NGRAPH_VLOG(0) << "Not running through nGraph. nGraph not enabled: "
+      NGRAPH_VLOG(1) << "Not running through nGraph. nGraph not enabled: "
                      << ngraph_not_enabled
                      << " Already processed: " << already_processed;
       NGraphClusterManager::EvictAllClusters();


### PR DESCRIPTION
The prints we were seeing in CI came due to this line:
https://github.com/tensorflow/ngraph-bridge/blob/master/test/opexecuter.cpp#L154

We deactivate ngraph when running on TF. Hence when running it bounces immediately away. but due to VLOG=0, we were seeing those prints. Making them VLOG=1