### PR TITLE
Add option to build from local copy of nGraph src

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -197,6 +197,7 @@ def main():
             cxx_abi = str(tf.__cxx11_abi_flag__)
 
     # Download nGraph if required.
+    ngraph_src_dir=''
     if arguments.ngraph_src_dir:
         ngraph_src_dir = arguments.ngraph_src_dir
 

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -60,7 +60,7 @@ def main():
     parser.add_argument(
         '--use_prebuilt_tensorflow',
         help="Skip building TensorFlow and use downloaded version.\n" +
-        "Note that in this case C++ unit tests won't be build for nGrapg-TF bridge",
+        "Note that in this case C++ unit tests won't be build for nGraph-TF bridge",
         action="store_true")
 
     parser.add_argument(
@@ -86,9 +86,15 @@ def main():
         action="store")
 
     parser.add_argument(
+        '--ngraph_src_dir',
+        type=str,
+        help="Local nGraph source directory to use. Overrides --ngraph_version.\n",
+        action="store")
+
+    parser.add_argument(
         '--ngraph_version',
         type=str,
-        help="nGraph version to use (Default: " + ngraph_version + ")\n",
+        help="nGraph version to use. Overridden by --ngraph_src_dir. (Default: " + ngraph_version + ")\n",
         action="store")
 
     parser.add_argument(
@@ -190,13 +196,18 @@ def main():
                   tf.__compiler_version__)
             cxx_abi = str(tf.__cxx11_abi_flag__)
 
-    # Download nGraph
-    if arguments.ngraph_version:
+    # Download nGraph if required.
+    if arguments.ngraph_src_dir:
+        ngraph_src_dir = arguments.ngraph_src_dir
+
+        print("Using local nGraph source in directory ",ngraph_src_dir)
+    elif arguments.ngraph_version:
         ngraph_version = arguments.ngraph_version
 
-    print("nGraph Version: ", ngraph_version)
-    download_repo("ngraph", "https://github.com/NervanaSystems/ngraph.git",
-                  ngraph_version)
+        print("nGraph Version: ", ngraph_version)
+        download_repo("ngraph", "https://github.com/NervanaSystems/ngraph.git",
+                      ngraph_version)
+        ngraph_src_dir='./ngraph'
 
     # Now build nGraph
     ngraph_cmake_flags = [
@@ -238,7 +249,7 @@ def main():
     else:
         ngraph_cmake_flags.extend(["-DNGRAPH_UNIT_TEST_ENABLE=NO"])
 
-    build_ngraph(build_dir, "./ngraph", ngraph_cmake_flags, verbosity)
+    build_ngraph(build_dir, ngraph_src_dir, ngraph_cmake_flags, verbosity)
 
     # Next build CMAKE options for the bridge
     tf_src_dir = os.path.abspath("tensorflow")

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -197,7 +197,7 @@ def main():
             cxx_abi = str(tf.__cxx11_abi_flag__)
 
     # Download nGraph if required.
-    ngraph_src_dir=''
+    ngraph_src_dir='./ngraph'
     if arguments.ngraph_src_dir:
         ngraph_src_dir = arguments.ngraph_src_dir
 
@@ -208,7 +208,6 @@ def main():
         print("nGraph Version: ", ngraph_version)
         download_repo("ngraph", "https://github.com/NervanaSystems/ngraph.git",
                       ngraph_version)
-        ngraph_src_dir='./ngraph'
 
     # Now build nGraph
     ngraph_cmake_flags = [

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -202,8 +202,9 @@ def main():
         ngraph_src_dir = arguments.ngraph_src_dir
 
         print("Using local nGraph source in directory ",ngraph_src_dir)
-    elif arguments.ngraph_version:
-        ngraph_version = arguments.ngraph_version
+    else:
+        if arguments.ngraph_version:
+            ngraph_version = arguments.ngraph_version
 
         print("nGraph Version: ", ngraph_version)
         download_repo("ngraph", "https://github.com/NervanaSystems/ngraph.git",


### PR DESCRIPTION
Currently it's a little hard to use `build_ngtf.py` if you are actively working on something inside `ngraph`, since that script requires a git ref (so you have to check in every small change). With this you can do something like:

```
$ ./build_ngtf.py --ngraph_src_dir=/localdisk/amprocte/Work/ngraph
```