### PR TITLE
Sarkars/tf2ngraph out savedmodel master

### DIFF
--- a/python/ngraph_bridge/__init__.in.py
+++ b/python/ngraph_bridge/__init__.in.py
@@ -34,6 +34,8 @@ from tensorflow.core.framework import attr_value_pb2
 from tensorflow.python.framework import ops
 
 from tensorflow.core.protobuf import rewriter_config_pb2
+from tensorflow.python.framework import load_library
+
 
 import ctypes
 
@@ -92,8 +94,10 @@ if (TF_INSTALLED_VER[0] == TF_NEEDED_VER[0]) and \
    (TF_INSTALLED_VER[1] == TF_NEEDED_VER[1]) and \
    ((TF_INSTALLED_VER[2].split('-'))[0] == (TF_NEEDED_VER[2].split('-'))[0]):
     libpath = os.path.dirname(__file__)
-    ngraph_bridge_lib = ctypes.cdll.LoadLibrary(
-        os.path.join(libpath, 'libngraph_bridge.' + ext))
+    full_lib_path = os.path.join(libpath, 'libngraph_bridge.' + ext)
+    _ = load_library.load_op_library(full_lib_path)
+    ngraph_bridge_lib = ctypes.cdll.LoadLibrary(full_lib_path)
+
 else:
     raise ValueError(
         "Error: Installed TensorFlow version {0}\nnGraph bridge built with: {1}"
@@ -105,7 +109,6 @@ def requested():
         "_ngraph_requested":
         attr_value_pb2.AttrValue(b=True)
     })
-
 
 ngraph_bridge_lib.ngraph_is_enabled.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_list_backends.restype = ctypes.c_bool
@@ -136,6 +139,7 @@ def enable():
     ngraph_bridge_lib.ngraph_enable()
 
 
+
 def disable():
     ngraph_bridge_lib.ngraph_disable()
 
@@ -151,7 +155,7 @@ def backends_len():
 def list_backends():
     len_backends = backends_len()
     result = (ctypes.c_char_p * len_backends)()
-    if not ngraph_bridge_lib.ngraph_list_backends(result, len_backends):
+    if ngraph_bridge_lib.ngraph_list_backends(result, len_backends):
         raise Exception("Expected " + str(len_backends) +
                         " backends, but got some  other number of backends")
     list_result = list(result)
@@ -163,7 +167,7 @@ def list_backends():
 
 
 def set_backend(backend):
-    if not ngraph_bridge_lib.ngraph_set_backend(backend.encode("utf-8")):
+    if ngraph_bridge_lib.ngraph_set_backend(backend.encode("utf-8")):
         raise Exception("Backend " + backend + " unavailable.")
 
 
@@ -174,7 +178,7 @@ def is_supported_backend(backend):
 
 def get_currently_set_backend_name():
     result = (ctypes.c_char_p * 1)()
-    if not ngraph_bridge_lib.ngraph_get_currently_set_backend_name(result):
+    if ngraph_bridge_lib.ngraph_get_currently_set_backend_name(result):
         raise Exception("Cannot get currently set backend")
     list_result = list(result)
     return list_result[0].decode("utf-8")
@@ -199,7 +203,7 @@ def is_grappler_enabled():
 
 def update_config(config):
     #updating session config if grappler is enabled
-    if(ngraph_bridge_lib.ngraph_tf_is_grappler_enabled()):
+    if (ngraph_bridge_lib.ngraph_tf_is_grappler_enabled()):
         rewrite_options = rewriter_config_pb2.RewriterConfig(
             meta_optimizer_iterations=rewriter_config_pb2.RewriterConfig.ONE,
             min_graph_nodes=-1,
@@ -219,12 +223,4 @@ def set_disabled_ops(unsupported_ops):
 def get_disabled_ops():
     return ngraph_bridge_lib.ngraph_get_disabled_ops()
 
-__version__ = \
-  "nGraph bridge version: " + str(ngraph_bridge_lib.ngraph_tf_version()) + "\n" + \
-  "nGraph version used for this build: " + str(ngraph_bridge_lib.ngraph_lib_version()) + "\n" + \
-  "TensorFlow version used for this build: " + TF_GIT_VERSION_BUILT_WITH + "\n" \
-  "CXX11_ABI flag used for this build: " + str(ngraph_bridge_lib.ngraph_tf_cxx11_abi_flag()) + "\n" \
-  "nGraph bridge built with Grappler: " + str(ngraph_bridge_lib.ngraph_tf_is_grappler_enabled()) + "\n" \
-  "nGraph bridge built with Variables and Optimizers Enablement: " \
-      + str(ngraph_bridge_lib.ngraph_tf_are_variables_enabled())
-
+__version__ = "HELLO"

--- a/python/ngraph_bridge/__init__.in.py
+++ b/python/ngraph_bridge/__init__.in.py
@@ -201,7 +201,7 @@ def is_grappler_enabled():
 
 def update_config(config):
     #updating session config if grappler is enabled
-    if (ngraph_bridge_lib.ngraph_tf_is_grappler_enabled()):
+    if(ngraph_bridge_lib.ngraph_tf_is_grappler_enabled()):
         rewrite_options = rewriter_config_pb2.RewriterConfig(
             meta_optimizer_iterations=rewriter_config_pb2.RewriterConfig.ONE,
             min_graph_nodes=-1,

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -161,8 +161,6 @@ def save_gdef_to_protobuf(gdef, location, as_text):
 
 
 def save_model(gdef, format, location):
-    if format == 'savedmodel':
-        raise Exception("TODO: Unimplemented")
     return {
         'savedmodel': save_gdef_to_savedmodel,
         'pbtxt': partial(save_gdef_to_protobuf, as_text=True),


### PR DESCRIPTION
Without loading the .so library through load_library, the ngencapsulate op is not registered in op_def_registry. That causes savedmodel generation to fail. Fixing that