### PR TITLE
sarkars/int to size_t

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -2238,7 +2238,7 @@ static Status TranslateLogSoftmaxOp(
   shared_ptr<ng::Node> ng_inp;
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_inp));
   auto inp_shape = ng_inp->get_shape();
-  int rank = inp_shape.size();
+  size_t rank = inp_shape.size();
   auto ng_axis = ng::AxisSet{rank - 1};
   // Batch i, class j
   // logsoftmax[i, j] = logits[i, j] - log(sum(exp(logits[i])))


### PR DESCRIPTION
`AxisSet` is a subclass of `vector<size_t>`. Passing it a `size_t` instead of `int` to remove warning/buildbreak