### PR TITLE
Add exit code logging for MacOS automated builds

### DIFF
--- a/test/ci/macos/run-mac-build-test-ngtf.sh
+++ b/test/ci/macos/run-mac-build-test-ngtf.sh
@@ -92,6 +92,8 @@ echo  ' '
 
 cd "${bridge_dir}"
 ./build_ngtf.py
+exit_code=$?
+echo "Exit status for build_ngtf.py is ${exit_code}"
 
 xtime="$(date)"
 echo  ' '
@@ -100,6 +102,8 @@ echo  ' '
 
 cd "${bridge_dir}"
 ./test_ngtf.py
+exit_code=$?
+echo "Exit status for test_ngtf.py is ${exit_code}"
 
 xtime="$(date)"
 echo ' '


### PR DESCRIPTION
Add logging of exit codes for build_ngtf.py and test_ngtf.py in automated MacOS builds.

Successful testing: https://aipg-rancher.intel.com/jenkins/algo/job/tf-ng-bridge-mac-daily-build/140/