### PR TITLE
sarkars/Continue to resnet test

### DIFF
--- a/test/ci/buildkite/ngtf-gpu_ubuntu.yaml
+++ b/test/ci/buildkite/ngtf-gpu_ubuntu.yaml
@@ -77,7 +77,8 @@
     agents:
     - "queue=gpu"
 
-  - wait
+  - wait: ~
+    continue_on_failure: true
 
   - command: |
       source /localdisk/buildkite/artifacts/$BUILDKITE_BUILD_ID/venv/bin/activate 

--- a/test/ci/buildkite/test_runner.py
+++ b/test/ci/buildkite/test_runner.py
@@ -121,8 +121,8 @@ def main():
             iterations = 10
             if arguments.backend:
                 if 'GPU' in arguments.backend:
-                    batch_size = 64
-                    iterations = 100
+                    batch_size = 16
+                    iterations = 20
             run_resnet50_from_artifacts('./', arguments.artifacts_dir,
                                         batch_size, iterations)
     else:

--- a/test/ci/buildkite/test_runner.py
+++ b/test/ci/buildkite/test_runner.py
@@ -121,8 +121,8 @@ def main():
             iterations = 10
             if arguments.backend:
                 if 'GPU' in arguments.backend:
-                    batch_size = 16
-                    iterations = 20
+                    batch_size = 4
+                    iterations = 5
             run_resnet50_from_artifacts('./', arguments.artifacts_dir,
                                         batch_size, iterations)
     else:


### PR DESCRIPTION
Minor change to make the GPU ci pipeline continue onto the resnet tests, even if TF pytests fail