### PR TITLE
Log parser fix to add the last subgraph to the results

### DIFF
--- a/tools/log_parser.py
+++ b/tools/log_parser.py
@@ -49,6 +49,10 @@ def parse_logs(log_lines):
                 curr_result['num_ng_clusters'] = int(
                     line.split(':')[-1].strip())
             # TODO: fill other information as needed
+
+    # add the last subgraph to all_results
+    all_results[str(ctr)] = curr_result
+    
     return all_results
 
 


### PR DESCRIPTION
As the log parser loops through lines in the log, it adds a subgraph's info to the results dictionary when it comes across the start of a new subgraph. The last subgraph was getting missed, since it wasn't getting added to the results dictionary. This PR fixes that issue by adding the last subgraph to the results dictionary at the end.