### PR TITLE
Shrestha/Fix --num_inter_threads

### DIFF
--- a/ngraph_bridge/enable_variable_ops/ngraph_assign_op.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_assign_op.cc
@@ -101,7 +101,7 @@ class NGraphAssignOp : public OpKernel {
                    IsNgraphTFLogTensorCopiesEnabled(ng_graph_id_, log_copies));
     std::stringstream copy_log_str;
     copy_log_str << "KERNEL[" << type_string() << "]: " << name()
-                 << " ,Copy_TF " << PrintBool(copy_to_tf_)
+                 << " ,copy-to-tf " << PrintBool(copy_to_tf_)
                  << ", is_tf_just_looking " << PrintBool(is_tf_just_looking_)
                  << ", just_looking " << PrintBool(just_looking_) << "\n";
     int number_of_copies = 0;
@@ -131,7 +131,9 @@ class NGraphAssignOp : public OpKernel {
 
     // Get input[1]
 
-    // input[1] cannot be from NGraphEncap Op
+    // The NGraphAssign Ops with input[1] from NGraphEncap Op are removed
+    // in the RemoveNGraphAssigns phase in rewrite pass
+    // Assert input[1] is not from NGraphEncap Op
     // No way to get input node and check its type
     string input_1_name = def().input(1);
     OP_REQUIRES(
@@ -151,7 +153,7 @@ class NGraphAssignOp : public OpKernel {
     if (copy_to_tf_) {
       if (var->copy_ng_to_tf()) {
         number_of_copies++;
-        copy_log_str << " COPY_TF ";
+        copy_log_str << " COPY_TO_TF ";
       }
 
       if (!is_tf_just_looking_) {

--- a/ngraph_bridge/enable_variable_ops/ngraph_enter_in_catalog.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_enter_in_catalog.cc
@@ -91,8 +91,12 @@ Status EnterInCatalog(Graph* graph, int graph_id) {
         NGRAPH_VLOG(4) << "output_index " << output_index;
         string key = NGraphCatalog::CreateNodeKey(graph_id, input_1->name(),
                                                   output_index);
+
         tuple<string, bool, bool> value =
             make_tuple(shared_name, copy_to_tf, is_tf_just_looking);
+        cout << "Adding to EncapOutputInfoMap "
+             << " Key: " << key << " ,Value: " << get<0>(value) << " "
+             << get<1>(value) << " " << get<2>(value) << endl;
         NGRAPH_VLOG(4) << "Adding to EncapOutputInfoMap ";
         NGRAPH_VLOG(4) << "Key: " << key;
         NGRAPH_VLOG(4) << "Value: " << get<0>(value) << " " << get<1>(value)

--- a/ngraph_bridge/enable_variable_ops/ngraph_enter_in_catalog.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_enter_in_catalog.cc
@@ -94,9 +94,6 @@ Status EnterInCatalog(Graph* graph, int graph_id) {
 
         tuple<string, bool, bool> value =
             make_tuple(shared_name, copy_to_tf, is_tf_just_looking);
-        cout << "Adding to EncapOutputInfoMap "
-             << " Key: " << key << " ,Value: " << get<0>(value) << " "
-             << get<1>(value) << " " << get<2>(value) << endl;
         NGRAPH_VLOG(4) << "Adding to EncapOutputInfoMap ";
         NGRAPH_VLOG(4) << "Key: " << key;
         NGRAPH_VLOG(4) << "Value: " << get<0>(value) << " " << get<1>(value)

--- a/ngraph_bridge/enable_variable_ops/ngraph_remove_ngraphassigns.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_remove_ngraphassigns.cc
@@ -45,7 +45,8 @@ Status RemoveNGraphAssigns(Graph* graph) {
             input_1->type_string());
       }
 
-      // Add control edge
+      // Add control edge between the Op providing the variable and the Op
+      // updating it
       graph->AddEdge(input_0, Graph::kControlSlot, input_1,
                      Graph::kControlSlot);
 

--- a/ngraph_bridge/enable_variable_ops/ngraph_remove_ngraphassigns.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_remove_ngraphassigns.cc
@@ -45,6 +45,10 @@ Status RemoveNGraphAssigns(Graph* graph) {
             input_1->type_string());
       }
 
+      // Add control edge
+      graph->AddEdge(input_0, Graph::kControlSlot, input_1,
+                     Graph::kControlSlot);
+
       // Handle input edges
       NGRAPH_VLOG(3) << "Handling input edges ";
       vector<const Edge*> remove_edges;

--- a/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
@@ -323,16 +323,12 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
                  "Graph with Variables Rewritten for Tracking");
     }
 
-    cout << " Enter in Catalog " << endl;
-
     // 6. Enter in catalog then.
     TF_RETURN_IF_ERROR(EnterInCatalog(options.graph->get(), idx));
     if (DumpCatalogedGraphs()) {
       DumpGraphs(options, idx, "cataloged",
                  "Graph with Variables Inputs Entered in Catalog");
     }
-
-    cout << "Remove Assigns " << endl;
 
     // 7. Remove Certain NGraphAssigns then.
     TF_RETURN_IF_ERROR(RemoveNGraphAssigns(options.graph->get()));

--- a/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
@@ -316,24 +316,28 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
                  "Graph with Clusters Encapsulated");
     }
 
-    // Rewrite for tracking then, if requested, dump the graphs.
+    // 5. Rewrite for tracking then, if requested, dump the graphs.
     TF_RETURN_IF_ERROR(RewriteForTracking(options.graph->get(), idx));
     if (DumpTrackedGraphs()) {
       DumpGraphs(options, idx, "tracked",
                  "Graph with Variables Rewritten for Tracking");
     }
 
-    // Enter in catalog then.
+    cout << " Enter in Catalog " << endl;
+
+    // 6. Enter in catalog then.
     TF_RETURN_IF_ERROR(EnterInCatalog(options.graph->get(), idx));
     if (DumpCatalogedGraphs()) {
       DumpGraphs(options, idx, "cataloged",
                  "Graph with Variables Inputs Entered in Catalog");
     }
 
-    // Remove Certain NGraphAssigns then.
+    cout << "Remove Assigns " << endl;
+
+    // 7. Remove Certain NGraphAssigns then.
     TF_RETURN_IF_ERROR(RemoveNGraphAssigns(options.graph->get()));
     if (DumpRemoveNGraphAssignsGraphs()) {
-      DumpGraphs(options, idx, "ngraphssigns_optimized",
+      DumpGraphs(options, idx, "ngraphassigns_optimized",
                  "Graph with NGraphAssigns Optimized/Removed");
     }
 

--- a/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
@@ -108,6 +108,8 @@ NGraphVariableOp::NGraphVariableOp(OpKernelConstruction* context)
                  << is_tf_just_looking_ << " ,copy-to-tf " << copy_to_tf_
                  << " ,Graph ID " << ng_graph_id_ << " ,backend_name "
                  << ng_backend_name_;
+
+  cout << "NGraphVariable:: Constructor called for: " << def().name() << endl;
 }
 
 NGraphVariableOp::~NGraphVariableOp() {
@@ -125,6 +127,8 @@ void NGraphVariableOp::Compute(OpKernelContext* ctx) {
                  << is_tf_just_looking_ << " ,copy-to-tf " << copy_to_tf_
                  << " ,Graph ID " << ng_graph_id_ << " ,backend_name "
                  << ng_backend_name_;
+
+  cout << "NGraphVariable:: Compute called for: " << def().name() << endl;
 
   std::ostringstream oss;
   oss << "NGraphVariable: " << my_instance_id << ": " << name();

--- a/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
@@ -138,9 +138,10 @@ void NGraphVariableOp::Compute(OpKernelContext* ctx) {
   OP_REQUIRES_OK(ctx,
                  IsNgraphTFLogTensorCopiesEnabled(ng_graph_id_, log_copies));
   std::stringstream copy_log_str;
-  copy_log_str << "KERNEL[" << type_string() << "]: " << name() << " ,Copy_TF "
-               << PrintBool(copy_to_tf_) << " ,is_tf_just_looking "
-               << PrintBool(is_tf_just_looking_) << "\n";
+  copy_log_str << "KERNEL[" << type_string() << "]: " << name()
+               << " ,copy-to-tf " << PrintBool(copy_to_tf_)
+               << " ,is_tf_just_looking " << PrintBool(is_tf_just_looking_)
+               << "\n";
   int number_of_copies = 0;
 
   mutex_lock l(init_mu_);
@@ -206,7 +207,7 @@ void NGraphVariableOp::Compute(OpKernelContext* ctx) {
     if (!just_synced) {
       if (var->copy_ng_to_tf()) {
         number_of_copies++;
-        copy_log_str << " COPY_TF ";
+        copy_log_str << " COPY_TO_TF ";
       }
       NGRAPH_VLOG(4) << "Copying to TF Tensor";
     }

--- a/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_tracked_variable.cc
@@ -108,8 +108,6 @@ NGraphVariableOp::NGraphVariableOp(OpKernelConstruction* context)
                  << is_tf_just_looking_ << " ,copy-to-tf " << copy_to_tf_
                  << " ,Graph ID " << ng_graph_id_ << " ,backend_name "
                  << ng_backend_name_;
-
-  cout << "NGraphVariable:: Constructor called for: " << def().name() << endl;
 }
 
 NGraphVariableOp::~NGraphVariableOp() {
@@ -127,8 +125,6 @@ void NGraphVariableOp::Compute(OpKernelContext* ctx) {
                  << is_tf_just_looking_ << " ,copy-to-tf " << copy_to_tf_
                  << " ,Graph ID " << ng_graph_id_ << " ,backend_name "
                  << ng_backend_name_;
-
-  cout << "NGraphVariable:: Compute called for: " << def().name() << endl;
 
   std::ostringstream oss;
   oss << "NGraphVariable: " << my_instance_id << ": " << name();

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -78,7 +78,8 @@ class NGraphEncapsulateOp : public OpKernel {
 
     NGRAPH_VLOG(1) << "NGraphEncapsulateOp: " << my_instance_id
                    << " Name: " << name();
-
+    cout << "NGraphEncapsulateOp::Constructor starting for cluster " << name()
+         << endl;
     GraphDef* graph_def;
 
     OP_REQUIRES_OK(ctx, ctx->GetAttr<int>("ngraph_cluster", &m_ngraph_cluster));
@@ -514,6 +515,9 @@ class NGraphEncapsulateOp : public OpKernel {
     std::lock_guard<std::mutex> lock(m_compute_lock);
     NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute starting for cluster "
                    << m_ngraph_cluster;
+
+    cout << "NGraphEncapsulateOp::Compute starting for cluster "
+         << m_ngraph_cluster << endl;
 
     ngraph::Event event_func_maybe_create("FunctionMaybeCreate", name(), "");
     Timer function_lookup_or_create;

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -871,7 +871,7 @@ class NGraphEncapsulateOp : public OpKernel {
           if (NGraphCatalog::GetCopyToTFFromEncapOutputInfoMap(output_key)) {
             if (var->copy_ng_to_tf()) {
               number_of_copies++;
-              copy_log_str << " COPY_TF ";
+              copy_log_str << " COPY_TO_TF ";
             }
             if (!NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(
                     output_key)) {

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -78,8 +78,7 @@ class NGraphEncapsulateOp : public OpKernel {
 
     NGRAPH_VLOG(1) << "NGraphEncapsulateOp: " << my_instance_id
                    << " Name: " << name();
-    cout << "NGraphEncapsulateOp::Constructor starting for cluster " << name()
-         << endl;
+
     GraphDef* graph_def;
 
     OP_REQUIRES_OK(ctx, ctx->GetAttr<int>("ngraph_cluster", &m_ngraph_cluster));
@@ -515,9 +514,6 @@ class NGraphEncapsulateOp : public OpKernel {
     std::lock_guard<std::mutex> lock(m_compute_lock);
     NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute starting for cluster "
                    << m_ngraph_cluster;
-
-    cout << "NGraphEncapsulateOp::Compute starting for cluster "
-         << m_ngraph_cluster << endl;
 
     ngraph::Event event_func_maybe_create("FunctionMaybeCreate", name(), "");
     Timer function_lookup_or_create;

--- a/test/graph_rewrites/remove_ngraphassigns.cc
+++ b/test/graph_rewrites/remove_ngraphassigns.cc
@@ -184,10 +184,18 @@ TEST(RemoveNGraphAssigns, Graph2) {
     edge_count++;
   }
 
+  // Assert on edges connected to add
   ASSERT_EQ(edge_count, 3);
   ASSERT_EQ(add_in_0, node_map.at("Var"));
   ASSERT_EQ(add_in_1, node_map.at(encap_op_name));
   ASSERT_EQ(add_in_ctrl, node_map.at(encap_op_name));
+
+  // Assert on control edge between Var and Encap
+  for (auto edge : add_in_0->out_edges()) {
+    if ((edge != nullptr) && (edge->IsControlEdge())) {
+      ASSERT_EQ(add_in_1, edge->dst());
+    }
+  }
 }
 
 // Var       Const
@@ -280,6 +288,13 @@ TEST(RemoveNGraphAssigns, Graph3) {
   ASSERT_EQ(assign_in_0, node_map.at("Var"));
   ASSERT_EQ(assign_in_1, node_map.at(encap_op_name));
   ASSERT_EQ(assign_in_ctrl, node_map.at(encap_op_name));
+
+  // Assert on control edge between Var and Encap
+  for (auto edge : assign_in_0->out_edges()) {
+    if ((edge != nullptr) && (edge->IsControlEdge())) {
+      ASSERT_EQ(assign_in_1, edge->dst());
+    }
+  }
 }
 
 // Var       Const
@@ -385,6 +400,13 @@ TEST(RemoveNGraphAssigns, Graph4) {
   ASSERT_EQ(add_in_0, node_map.at("Var"));
   ASSERT_EQ(add_in_1, node_map.at(encap_op_name));
   ASSERT_EQ(add_in_ctrl, node_map.at(encap_op_name));
+
+  // Assert on control edge between Var and Encap
+  for (auto edge : add_in_0->out_edges()) {
+    if ((edge != nullptr) && (edge->IsControlEdge())) {
+      ASSERT_EQ(add_in_1, edge->dst());
+    }
+  }
 }
 
 // Var       Const


### PR DESCRIPTION
Added Control Edge between input_0 and input_1 of NGAssign being removed. Without this in certain cases, there was no dependency between the Variable to be updated and Encap that's updating the Var once the NGraphAssign was removed. 
Encap would get computed before the Var causing the error.