### PR TITLE
Fix resource leaking due to undeleted ngraph::Executable

### DIFF
--- a/ngraph_bridge/ngraph_freshness_tracker.cc
+++ b/ngraph_bridge/ngraph_freshness_tracker.cc
@@ -26,7 +26,7 @@ namespace ngraph_bridge {
 
 void NGraphFreshnessTracker::MarkFresh(
     const void* base_pointer,
-    std::shared_ptr<ngraph::runtime::Executable> user) {
+    const std::shared_ptr<ngraph::runtime::Executable>& user) {
   mutex_lock l(mu_);
   auto it = freshness_map_.find(base_pointer);
   if (it != freshness_map_.end()) {
@@ -36,7 +36,7 @@ void NGraphFreshnessTracker::MarkFresh(
 
 bool NGraphFreshnessTracker::IsFresh(
     const void* base_pointer,
-    std::shared_ptr<ngraph::runtime::Executable> user) {
+    const std::shared_ptr<ngraph::runtime::Executable>& user) {
   mutex_lock l(mu_);
   auto it = freshness_map_.find(base_pointer);
   if (it == freshness_map_.end()) {
@@ -69,9 +69,9 @@ void NGraphFreshnessTracker::RemoveTensor(const void* base_pointer) {
 }
 
 void NGraphFreshnessTracker::RemoveUser(
-    std::shared_ptr<ngraph::runtime::Executable> user) {
+    const std::shared_ptr<ngraph::runtime::Executable>& user) {
   mutex_lock l(mu_);
-  for (auto kv : freshness_map_) {
+  for (auto& kv : freshness_map_) {
     kv.second.erase(user);
   }
 }

--- a/ngraph_bridge/ngraph_freshness_tracker.h
+++ b/ngraph_bridge/ngraph_freshness_tracker.h
@@ -95,12 +95,12 @@ class NGraphFreshnessTracker : public ResourceBase {
   // If freshness_map_ has the base_pointer, then inserts the user function into
   // its set of user functions
   void MarkFresh(const void* base_pointer,
-                 std::shared_ptr<ngraph::runtime::Executable> user);
+                 const std::shared_ptr<ngraph::runtime::Executable>& user);
 
   // Checks if the freshness_map_ has the user function for base_pointer, else
   // returns false
   bool IsFresh(const void* base_pointer,
-               std::shared_ptr<ngraph::runtime::Executable> user);
+               const std::shared_ptr<ngraph::runtime::Executable>& user);
 
   // Removes all the functions for the base_pointer in the freshness_map_, i.e.
   // sets the set<ng::Function> for base_pointer to empty
@@ -114,7 +114,7 @@ class NGraphFreshnessTracker : public ResourceBase {
   void RemoveTensor(const void* base_pointer);
 
   // Removes the user function from the freshness_map_
-  void RemoveUser(std::shared_ptr<ngraph::runtime::Executable> user);
+  void RemoveUser(const std::shared_ptr<ngraph::runtime::Executable>& user);
 
  private:
   // mutex protecting the freshness_map_


### PR DESCRIPTION
In tf-bridge there is a freshness tracker, which is a key-value storage of {key=some pointer, value=set<shared_ptr< ngraph::Executable>>}. There is mechanism to iterate each key-value pair in it and destroy the shared_ptr< ngraph::Executable> in it so that the resource can be reclaimed. However in the implementation, it is done on a copy of key-value pair, instead of the original storage itself. The original freshness_map is untouched and the resource in it is not reclaimed as expected.

The rest of the change is about to reduce the unnecessary incrementation/decrementation of use_count of shared_ptr.