### PR TITLE
Sarkars/use in-graph ngfunc string instead of deserializing

### DIFF
--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -152,7 +152,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     }
 
     int function_size;
-    if (!m_do_aot){
+    if (!m_do_aot) {
       function_size = ng_function->get_graph_size() / 1024;  // kb unit
     }
 
@@ -165,7 +165,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
       file_name += ("_" + to_string(rank_id));
 #endif
       file_name += ".json";
-      if (m_do_aot){
+      if (m_do_aot) {
         NgraphSerialize(file_name, serialized_ng_function);
       } else {
         NgraphSerialize(file_name, ng_function);
@@ -181,7 +181,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
       int input_tensors_bytes_free = 0;
       evicted_ng_exec = m_ng_exec_map[m_lru.back()];
       m_ng_exec_map.erase(m_lru.back());
-      if (m_do_aot){
+      if (m_do_aot) {
         m_serialized_ng_function_map.erase(evicted_ng_exec);
       } else {
         m_ng_function_map.erase(evicted_ng_exec);
@@ -236,7 +236,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     } catch (const std::exception& exp) {
       BackendManager::UnlockBackend(m_op_backend_name);
       string file_name = "tf_function_error_" + m_name + ".json";
-      if (m_do_aot){
+      if (m_do_aot) {
         NgraphSerialize(file_name, serialized_ng_function);
       } else {
         NgraphSerialize(file_name, ng_function);
@@ -246,7 +246,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     } catch (...) {
       BackendManager::UnlockBackend(m_op_backend_name);
       string file_name = "tf_function_error_" + m_name + ".json";
-      if (m_do_aot){
+      if (m_do_aot) {
         NgraphSerialize(file_name, serialized_ng_function);
       } else {
         NgraphSerialize(file_name, ng_function);
@@ -260,7 +260,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     m_ng_exec_map[signature] = ng_exec;
 
     // caching ng_function to serialize to ngraph if needed
-    if (m_do_aot){
+    if (m_do_aot) {
       m_serialized_ng_function_map[ng_exec] = serialized_ng_function;
     } else {
       m_ng_function_map[ng_exec] = ng_function;
@@ -275,7 +275,8 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
                    << " Cache length: " << m_ng_exec_map.size()
                    << " Cluster: " << m_name << " Delta VM: " << delta_vm_mem
                    << " Delta RSS: " << delta_res_mem
-                   << (m_do_aot ? "" : " Function size: " + to_string(function_size))
+                   << (m_do_aot ? ""
+                                : " Function size: " + to_string(function_size))
                    << " KB Total RSS: " << rss / (1024 * 1024) << " GB "
                    << " VM: " << vm / (1024 * 1024) << " GB" << endl;
   }  // end of input signature not found in m_ng_exec_map
@@ -606,7 +607,7 @@ NGraphEncapsulateImpl::GetTensorsFromPipeline(
   return out_tpl;
 }
 
-void NGraphEncapsulateImpl::ClearExecMaps(){
+void NGraphEncapsulateImpl::ClearExecMaps() {
   m_ng_exec_input_cache_map.clear();
   m_ng_exec_output_cache_map.clear();
   m_ng_exec_map.clear();
@@ -615,13 +616,15 @@ void NGraphEncapsulateImpl::ClearExecMaps(){
   m_executable_pipelined_tensors_map.clear();
 }
 
-void NGraphEncapsulateImpl::DumpNgFunction(const string& file_name, std::shared_ptr<ngraph::runtime::Executable> ng_exec) {
-    if (m_do_aot) {
-      NgraphSerialize(file_name, m_serialized_ng_function_map[ng_exec]);
-    } else {
-      NgraphSerialize(file_name, m_ng_function_map[ng_exec]);
-    }
+void NGraphEncapsulateImpl::DumpNgFunction(
+    const string& file_name,
+    std::shared_ptr<ngraph::runtime::Executable> ng_exec) {
+  if (m_do_aot) {
+    NgraphSerialize(file_name, m_serialized_ng_function_map[ng_exec]);
+  } else {
+    NgraphSerialize(file_name, m_ng_function_map[ng_exec]);
   }
+}
 
 }  // namespace ngraph_bridge
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -252,13 +252,14 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     event_compile.Stop();
     ngraph::Event::write_trace(event_compile);
 
-    SetNgExecMap(signature, ng_exec);
+    m_ng_exec_map[signature] = ng_exec;
+
     // caching ng_function to serialize to ngraph if needed
     if (m_do_aot){
       // TODO: similar to a map exec->function, we may need a map exec->serialized_function
       // Union ng_function and string serialized_ng_function? How to hide (ng_func | string)
     } else {
-      SetNgFunctionMap(ng_exec, ng_function);
+      m_ng_function_map[ng_exec] = ng_function;
     }
 
     m_lru.push_front(signature);
@@ -348,8 +349,7 @@ Status NGraphEncapsulateImpl::AllocateNGInputTensors(
       // Fresh or stale, in case of CPU this step is never needed
       try {
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
-        int copies = number_of_copies;
-        SetNumberOfCopies(copies++);
+        number_of_copies++;
         copy_log_str << " COPY_INP_VAL[" << i << "]";
 #endif
         size_t copy_size =

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -134,6 +134,7 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     MemoryProfile(vm0, rss0);
 
     NGRAPH_VLOG(1) << "Compilation cache miss: " << m_name;
+    string serialized_ng_func;
     if (!m_do_aot) {
       TF_RETURN_IF_ERROR(Builder::TranslateGraph(input_shapes, static_input_map,
                                                  &m_graph, ng_function));
@@ -145,22 +146,29 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
             "Expected to find AOT precompiled ng function of signature: ",
             signature);
       }
-      ng_function = ng::deserialize(itr->second);
+      serialized_ng_func = itr->second;
+      ng_function = ng::deserialize(serialized_ng_func);
     }
 
-    auto function_size = ng_function->get_graph_size() / 1024;  // kb unit
+    int function_size;
+    if (!m_do_aot){
+      function_size = ng_function->get_graph_size() / 1024;  // kb unit
+    }
 
     // Serialize to nGraph if needed
     if (std::getenv("NGRAPH_ENABLE_SERIALIZE") != nullptr) {
-      std::string file_name = "tf_function_" + m_name + ".json";
-      NgraphSerialize("tf_function_" + m_name + ".json", ng_function);
+      std::string file_name = "tf_function_" + m_name;
 #if defined NGRAPH_DISTRIBUTED
       int rank_id;
       rank_id = ng::get_distributed_interface()->get_rank();
-      NgraphSerialize(
-          "tf_function_" + m_name + "_" + to_string(rank_id) + ".json",
-          ng_function);
+      file_name += ("_" + to_string(rank_id));
 #endif
+      file_name += ".json";
+      if (m_do_aot){
+        NgraphSerialize(file_name, serialized_ng_func);
+      } else {
+        NgraphSerialize(file_name, ng_function);
+      }
     }
     // Evict the cache if the number of elements exceeds the limit
     const char* cache_depth_specified =
@@ -222,12 +230,22 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
       }
     } catch (const std::exception& exp) {
       BackendManager::UnlockBackend(m_op_backend_name);
-      NgraphSerialize("tf_function_error_" + m_name + ".json", ng_function);
+      string file_name = "tf_function_error_" + m_name + ".json";
+      if (m_do_aot){
+        NgraphSerialize(file_name, serialized_ng_func);
+      } else {
+        NgraphSerialize(file_name, ng_function);
+      }
       return errors::Internal("Caught exception while compiling op_backend: ",
                               exp.what(), "\n");
     } catch (...) {
       BackendManager::UnlockBackend(m_op_backend_name);
-      NgraphSerialize("tf_function_error_" + m_name + ".json", ng_function);
+      string file_name = "tf_function_error_" + m_name + ".json";
+      if (m_do_aot){
+        NgraphSerialize(file_name, serialized_ng_func);
+      } else {
+        NgraphSerialize(file_name, ng_function);
+      }
       return errors::Internal("Error in compiling op_backend\n");
     }
     BackendManager::UnlockBackend(m_op_backend_name);
@@ -245,9 +263,9 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     auto delta_res_mem = rss - rss0;
     NGRAPH_VLOG(1) << "NGRAPH_TF_CACHE_PROFILE: OP_ID: " << my_instance_id
                    << " Cache length: " << m_ng_exec_map.size()
-                   << "  Cluster: " << m_name << " Delta VM: " << delta_vm_mem
-                   << "  Delta RSS: " << delta_res_mem
-                   << "  Function size: " << function_size
+                   << " Cluster: " << m_name << " Delta VM: " << delta_vm_mem
+                   << " Delta RSS: " << delta_res_mem
+                   << (m_do_aot ? "" : " Function size: " + to_string(function_size))
                    << " KB Total RSS: " << rss / (1024 * 1024) << " GB "
                    << " VM: " << vm / (1024 * 1024) << " GB" << endl;
   }  // end of input signature not found in m_ng_exec_map

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -254,7 +254,12 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
 
     SetNgExecMap(signature, ng_exec);
     // caching ng_function to serialize to ngraph if needed
-    SetNgFunctionMap(ng_exec, ng_function);
+    if (m_do_aot){
+      // TODO: similar to a map exec->function, we may need a map exec->serialized_function
+      // Union ng_function and string serialized_ng_function? How to hide (ng_func | string)
+    } else {
+      SetNgFunctionMap(ng_exec, ng_function);
+    }
 
     m_lru.push_front(signature);
     // Memory after

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -615,6 +615,14 @@ void NGraphEncapsulateImpl::ClearExecMaps(){
   m_executable_pipelined_tensors_map.clear();
 }
 
+void NGraphEncapsulateImpl::DumpNgFunction(const string& file_name, std::shared_ptr<ngraph::runtime::Executable> ng_exec) {
+    if (m_do_aot) {
+      NgraphSerialize(file_name, m_serialized_ng_function_map[ng_exec]);
+    } else {
+      NgraphSerialize(file_name, m_ng_function_map[ng_exec]);
+    }
+  }
+
 }  // namespace ngraph_bridge
 
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -156,6 +156,8 @@ class NGraphEncapsulateImpl {
 
   void SetName(string name) { m_name = name; }
 
+  void DumpNgFunction(const string&, std::shared_ptr<ngraph::runtime::Executable>);
+
   Status ParseNodeAttributes(
       const google::protobuf::Map<string, AttrValue>& additional_attributes,
       std::unordered_map<std::string, std::string>* additional_attribute_map);

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -85,17 +85,19 @@ class NGraphEncapsulateImpl {
       const ng::element::Type& ng_element_type, const ng::Shape& ng_shape,
       std::shared_ptr<ng::runtime::Tensor> tensor_from_pipeline);
 
-  // Accessors(getters and setters) for the private data members of
-  // NgraphEncapsulateImpl class
-  // needed by
-  // NgraphEncapsulateOp class
+// Accessors(getters and setters) for the private data members of
+// NgraphEncapsulateImpl class needed by
+// NgraphEncapsulateOp class
+
+#if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   const int& GetNumberOfCopies() { return number_of_copies; }
+  void SetNumberOfCopies(const int& number) { number_of_copies = number; }
+  int GetGraphId() { return m_graph_id; }
+#endif
 
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
 
   void SetNgraphCluster(const int& cluster) { m_ngraph_cluster = cluster; }
-
-  int GetGraphId() { return m_graph_id; }
 
   void SetGraphId(const int& graph_id) { m_graph_id = graph_id; }
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -156,7 +156,8 @@ class NGraphEncapsulateImpl {
 
   void SetName(string name) { m_name = name; }
 
-  void DumpNgFunction(const string&, std::shared_ptr<ngraph::runtime::Executable>);
+  void DumpNgFunction(const string&,
+                      std::shared_ptr<ngraph::runtime::Executable>);
 
   Status ParseNodeAttributes(
       const google::protobuf::Map<string, AttrValue>& additional_attributes,
@@ -209,8 +210,8 @@ class NGraphEncapsulateImpl {
                      std::shared_ptr<ngraph::Function>>
       m_ng_function_map;
 
-  std::unordered_map<std::shared_ptr<ngraph::runtime::Executable>,
-                     std::string> m_serialized_ng_function_map;
+  std::unordered_map<std::shared_ptr<ngraph::runtime::Executable>, std::string>
+      m_serialized_ng_function_map;
   NgFunctionIOCache m_ng_exec_input_cache_map;
   NgFunctionIOCache m_ng_exec_output_cache_map;
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -137,20 +137,14 @@ class NGraphEncapsulateImpl {
     return m_ng_exec_map;
   }
 
-  void ClearNgExecMap() { m_ng_exec_map.clear(); }
+  void ClearExecMaps();
 
-
-  void ClearNgFunctionMap() { m_ng_function_map.clear(); }
   // TODO:sindhu have another get function for output_cache which is only
   // readable
   std::vector<std::pair<void*, shared_ptr<ng::runtime::Tensor>>>&
   GetNgExecOutputCacheMap(std::shared_ptr<ngraph::runtime::Executable> exec) {
     return m_ng_exec_output_cache_map[exec];
   }
-
-  void ClearNgExecInputCache() { m_ng_exec_input_cache_map.clear(); }
-
-  void ClearNgExecOutputCache() { m_ng_exec_output_cache_map.clear(); }
 
   NGraphFreshnessTracker* GetNgraphFreshnessTracker() {
     return m_freshness_tracker;
@@ -213,6 +207,8 @@ class NGraphEncapsulateImpl {
                      std::shared_ptr<ngraph::Function>>
       m_ng_function_map;
 
+  std::unordered_map<std::shared_ptr<ngraph::runtime::Executable>,
+                     std::string> m_serialized_ng_function_map;
   NgFunctionIOCache m_ng_exec_input_cache_map;
   NgFunctionIOCache m_ng_exec_output_cache_map;
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -148,11 +148,6 @@ class NGraphEncapsulateImpl {
 
   void ClearNgExecMap() { m_ng_exec_map.clear(); }
 
-  std::unordered_map<std::shared_ptr<ngraph::runtime::Executable>,
-                     std::shared_ptr<ngraph::Function>>
-  GetNgFunctionMap() {
-    return m_ng_function_map;
-  }
 
   void SetNgFunctionMap(
       const std::shared_ptr<ngraph::runtime::Executable>& exec,

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -91,8 +91,6 @@ class NGraphEncapsulateImpl {
   // NgraphEncapsulateOp class
   const int& GetNumberOfCopies() { return number_of_copies; }
 
-  void SetNumberOfCopies(const int& number) { number_of_copies = number; }
-
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
 
   void SetNgraphCluster(const int& cluster) { m_ngraph_cluster = cluster; }
@@ -121,11 +119,9 @@ class NGraphEncapsulateImpl {
 
   bool GetLogCopies() { return log_copies; }
 
-  void SetLogCopies(bool value) { log_copies = value; }
-
   const string GetCopyLog() { return copy_log_str.str(); }
 
-  void SetCopyLog(const string str) { copy_log_str.str() = str; }
+  void AppendCopyLog(const string str) { copy_log_str << str; }
 
   const std::vector<bool> GetStaticInputVector() { return m_input_is_static; }
 
@@ -141,19 +137,8 @@ class NGraphEncapsulateImpl {
     return m_ng_exec_map;
   }
 
-  void SetNgExecMap(const std::string& ng_map_key,
-                    const std::shared_ptr<ngraph::runtime::Executable>& exec) {
-    m_ng_exec_map[ng_map_key] = exec;
-  }
-
   void ClearNgExecMap() { m_ng_exec_map.clear(); }
 
-
-  void SetNgFunctionMap(
-      const std::shared_ptr<ngraph::runtime::Executable>& exec,
-      const std::shared_ptr<ngraph::Function>& function) {
-    m_ng_function_map[exec] = function;
-  }
 
   void ClearNgFunctionMap() { m_ng_function_map.clear(); }
   // TODO:sindhu have another get function for output_cache which is only
@@ -161,13 +146,6 @@ class NGraphEncapsulateImpl {
   std::vector<std::pair<void*, shared_ptr<ng::runtime::Tensor>>>&
   GetNgExecOutputCacheMap(std::shared_ptr<ngraph::runtime::Executable> exec) {
     return m_ng_exec_output_cache_map[exec];
-  }
-
-  void SetNgExecOutputCacheMap(
-      const std::shared_ptr<ngraph::runtime::Executable>& exec,
-      const std::vector<std::pair<void*, shared_ptr<ng::runtime::Tensor>>>&
-          cache) {
-    m_ng_exec_output_cache_map[exec] = cache;
   }
 
   void ClearNgExecInputCache() { m_ng_exec_input_cache_map.clear(); }

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -252,11 +252,7 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
 
 #endif
 
-  ng_encap_impl.ClearNgExecInputCache();
-  ng_encap_impl.ClearNgExecOutputCache();
-  ng_encap_impl.ClearNgExecMap();
-  ng_encap_impl.ClearNgFunctionMap();
-  ng_encap_impl.ClearNgExecPipelinedTensorMap();
+  ng_encap_impl.ClearExecMaps();
 
   // Release the backend
   NGRAPH_VLOG(2) << "~NGraphEncapsulateOp():: ReleaseBackend";
@@ -284,7 +280,6 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
   std::vector<TensorShape> input_shapes;
   std::vector<const Tensor*> static_input_map;
-  std::shared_ptr<ngraph::Function> ng_function;
   std::shared_ptr<ngraph::runtime::Executable> ng_exec;
   ng::runtime::Backend* op_backend;
 

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -519,20 +519,15 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     try {
       ng_exec->call(ng_outputs, ng_inputs);
     } catch (const std::exception& exp) {
-      ng_function = ng_encap_impl.GetNgFunctionMap()[ng_exec];
       BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
-      // TODO : dont use ng_function for aot
-      NgraphSerialize("tf_function_error_" + ctx->op_kernel().name() + ".json",
-                      ng_function);
+      ng_encap_impl.DumpNgFunction("tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
       OP_REQUIRES(ctx, false,
                   errors::Internal(
                       "Caught exception while executing nGraph computation: ",
                       exp.what(), "\n"));
     } catch (...) {
-      ng_function = ng_encap_impl.GetNgFunctionMap()[ng_exec];
       BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
-      NgraphSerialize("tf_function_error_" + ctx->op_kernel().name() + ".json",
-                      ng_function);
+      ng_encap_impl.DumpNgFunction("tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
       OP_REQUIRES(
           ctx, false,
           errors::Internal("Error in executing the nGraph computation\n"));

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -521,6 +521,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     } catch (const std::exception& exp) {
       ng_function = ng_encap_impl.GetNgFunctionMap()[ng_exec];
       BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
+      // TODO : dont use ng_function for aot
       NgraphSerialize("tf_function_error_" + ctx->op_kernel().name() + ".json",
                       ng_function);
       OP_REQUIRES(ctx, false,

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -491,7 +491,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       ng_encap_impl.SetNumberOfCopies(copies++);
       stringstream str;
       str << "Var_Sync[" << input_index << "] ";
-      ng_encap_impl.SetCopyLog(str.str());
+      ng_encap_impl.AppendCopyLog(str.str());
     }
 
     void* current_tf_ptr = (void*)DMAHelper::base(&ctx->input(input_index));
@@ -586,12 +586,12 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
           if (var->copy_ng_to_tf()) {
             int copies = ng_encap_impl.GetNumberOfCopies();
             ng_encap_impl.SetNumberOfCopies(copies++);
-            ng_encap_impl.SetCopyLog(" COPY_TO_TF ");
+            ng_encap_impl.AppendCopyLog(" COPY_TO_TF ");
           }
           if (!NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(
                   output_key)) {
             // Some tf op might update the ng-tensor value so mark it stale
-            ng_encap_impl.SetCopyLog(" SET_SYNC ");
+            ng_encap_impl.AppendCopyLog(" SET_SYNC ");
             var->set_sync_ng_tensor(true);
           }
         }
@@ -609,7 +609,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ng_encap_impl.SetNumberOfCopies(copies++);
         stringstream log;
         log << " COPY_OP_VAL[" << i << "]";
-        ng_encap_impl.SetCopyLog(log.str());
+        ng_encap_impl.AppendCopyLog(log.str());
 
         NGRAPH_VLOG(4) << "Copying Output " << def().name() << " ,index: " << i;
         auto ng_element_type = dst_ng_tensor->get_element_type();
@@ -662,7 +662,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   std::stringstream str;
   str << " Number of copies " << ng_encap_impl.GetNumberOfCopies() << "\n";
-  ng_encap_impl.SetCopyLog(str.str());
+  ng_encap_impl.AppendCopyLog(str.str());
   if (ng_encap_impl.GetLogCopies()) {
     cout << ng_encap_impl.GetCopyLog();
   }

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -515,14 +515,16 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       ng_exec->call(ng_outputs, ng_inputs);
     } catch (const std::exception& exp) {
       BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
-      ng_encap_impl.DumpNgFunction("tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
+      ng_encap_impl.DumpNgFunction(
+          "tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
       OP_REQUIRES(ctx, false,
                   errors::Internal(
                       "Caught exception while executing nGraph computation: ",
                       exp.what(), "\n"));
     } catch (...) {
       BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
-      ng_encap_impl.DumpNgFunction("tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
+      ng_encap_impl.DumpNgFunction(
+          "tf_function_error_" + ctx->op_kernel().name() + ".json", ng_exec);
       OP_REQUIRES(
           ctx, false,
           errors::Internal("Error in executing the nGraph computation\n"));

--- a/ngraph_bridge/ngraph_utils.cc
+++ b/ngraph_bridge/ngraph_utils.cc
@@ -309,20 +309,24 @@ Status CheckAxisDimInRange(std::vector<int64> axes, size_t rank) {
 }
 
 void NgraphSerialize(const std::string& file_name,
-                     const std::shared_ptr<ngraph::Function>& ng_function) {
+                     const std::string& serialized_ng_function) {
   NGRAPH_VLOG(0) << "Serializing graph to: " << file_name << std::endl;
-  std::string js = ngraph::serialize(ng_function, 4);
   std::ofstream f;
   f.exceptions(std::ofstream::failbit | std::ofstream::badbit);
   try {
     f.open(file_name);
-    f << js;
+    f << serialized_ng_function;
     f.close();
   } catch (std::ofstream::failure& e) {
     NGRAPH_VLOG(0) << "Exception opening/closing file " << file_name
                    << std::endl;
     NGRAPH_VLOG(0) << e.what() << std::endl;
   }
+}
+
+void NgraphSerialize(const std::string& file_name,
+                     const std::shared_ptr<ngraph::Function>& ng_function) {
+  NgraphSerialize(file_name, ngraph::serialize(ng_function, 4));
 }
 
 void MemoryProfile(long& vm_usage, long& resident_set) {

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -300,6 +300,10 @@ Status CheckAxisDimInRange(std::vector<int64> axes, size_t rank);
 void NgraphSerialize(const std::string&,
                      const std::shared_ptr<ngraph::Function>&);
 
+// Serialize a ngraph function into a file
+void NgraphSerialize(const std::string&,
+                     const std::string&);
+
 // Collect the total memory usage through /proc/self/stat
 void MemoryProfile(long&, long&);
 

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -301,8 +301,7 @@ void NgraphSerialize(const std::string&,
                      const std::shared_ptr<ngraph::Function>&);
 
 // Serialize a ngraph function into a file
-void NgraphSerialize(const std::string&,
-                     const std::string&);
+void NgraphSerialize(const std::string&, const std::string&);
 
 // Collect the total memory usage through /proc/self/stat
 void MemoryProfile(long&, long&);


### PR DESCRIPTION
Main change:
1. In case of AOT, we deserialize and serialize the ng function. No need to do that, we can directly pass the ng function to file.

Other changes:
1. Added an overload of `NgraphSerialize` that accepts a string to dump to file, rather than an ng_function itself
3. Removed some unused functions from impl, since they were not being used by ngraph_encapsulate_op.cc (such as `SetNgFunctionMap`)
4. Unified all the exec map clearing functions into one function `ClearExecMaps`
5. Some functions in impl like `GetNumberOfCopies`, `SetNumberOfCopies` and `GetGraphId` are only used in var-opts path. so moved them under`#if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)`
6. Corrected the behaviour or `SetCopyLog` and renamed it to `AppendCopyLog`
7. Added a new function `DumpNgFunction` that will dump the ng function in case of errors. It hides if its actually dumping the ngfunction or the serialized string (in case of aot) 



https://jira.devtools.intel.com/browse/NGTF-2255