### PR TITLE
shrestha/backend_error_message_fixes

### DIFF
--- a/ngraph_bridge/grappler/ngraph_optimizer.cc
+++ b/ngraph_bridge/grappler/ngraph_optimizer.cc
@@ -198,14 +198,11 @@ Status NgraphOptimizer::Optimize(tensorflow::grappler::Cluster* cluster,
   // using RewriteConfig
   string backend_creation_string = BackendManager::GetBackendCreationString(
       config_backend_name, config_device_id);
-  if (!config_backend_name.empty()) {
-    if (!BackendManager::IsSupportedBackend(backend_creation_string)) {
-      return errors::Internal("NGRAPH_TF_BACKEND: ", backend_creation_string,
-                              " is not supported");
-    }
-    NGRAPH_VLOG(1) << "Setting backend from the RewriteConfig "
-                   << backend_creation_string;
-  }
+
+  TF_RETURN_IF_ERROR(BackendManager::CanCreateBackend(backend_creation_string));
+  NGRAPH_VLOG(1) << "Setting backend from the RewriteConfig "
+                 << backend_creation_string;
+
   NGRAPH_VLOG(0) << "NGraph using backend: " << backend_creation_string;
 
   // 1. Mark for clustering then, if requested, dump the graphs.

--- a/ngraph_bridge/ngraph_api.cc
+++ b/ngraph_bridge/ngraph_api.cc
@@ -52,10 +52,6 @@ bool ngraph_set_backend(const char* backend) {
   return true;
 }
 
-extern bool ngraph_is_supported_backend(const char* backend) {
-  return IsSupportedBackend(string(backend));
-}
-
 extern bool ngraph_get_currently_set_backend_name(char** backend) {
   string bend;
   if (GetCurrentlySetBackendName(&bend) != tensorflow::Status::OK()) {
@@ -92,10 +88,6 @@ vector<string> ListBackends() {
 
 Status SetBackend(const string& type) {
   return BackendManager::SetBackendName(type);
-}
-
-bool IsSupportedBackend(const string& type) {
-  return BackendManager::IsSupportedBackend(type);
 }
 
 Status GetCurrentlySetBackendName(string* backend_name) {

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -36,9 +36,9 @@ map<std::string, int> BackendManager::ref_count_each_backend_;
 
 Status BackendManager::SetBackendName(const string& backend_name) {
   std::lock_guard<std::mutex> lock(BackendManager::ng_backend_name_mutex_);
-  if (backend_name.empty() || !IsSupportedBackend(backend_name)) {
-    return errors::Internal("Backend ", backend_name,
-                            " is not supported on nGraph");
+  auto status = BackendManager::CanCreateBackend(backend_name);
+  if (status != Status::OK()) {
+    return errors::Internal("Failed to set backend: ", status.error_message());
   }
   BackendManager::ng_backend_name_ = backend_name;
   return Status::OK();
@@ -58,8 +58,8 @@ Status BackendManager::CreateBackend(const string& backend_name) {
     }
 
     if (bend_ptr == nullptr) {
-      return errors::Internal("Could not create backend of type ",
-                              backend_name);
+      return errors::Internal("Could not create backend of type ", backend_name,
+                              " got nullptr");
     }
     std::unique_ptr<Backend> bend = std::unique_ptr<Backend>(new Backend);
     bend->backend_ptr = std::move(bend_ptr);
@@ -134,14 +134,22 @@ size_t BackendManager::GetNumOfSupportedBackends() {
 }
 
 bool BackendManager::IsSupportedBackend(const string& backend_name) {
-  auto status = BackendManager::CreateBackend(backend_name);
-  if (status != Status::OK()) {
-    return false;
+  vector<string> registered_backends =
+      ng::runtime::BackendManager::get_registered_backends();
+  vector<string>::iterator itr = find(registered_backends.begin(),
+                                      registered_backends.end(), backend_name);
+
+  return itr != registered_backends.end();
+};
+
+Status BackendManager::CanCreateBackend(const string& backend_string) {
+  auto status = BackendManager::CreateBackend(backend_string);
+  if (status == Status::OK()) {
+    // The call to create backend increases the ref count
+    // so releasing the backend here
+    BackendManager::ReleaseBackend(backend_string);
   }
-  // The call to create backend increases the ref count
-  // so releasing the backend here
-  BackendManager::ReleaseBackend(backend_name);
-  return true;
+  return status;
 };
 
 Status BackendManager::GetCurrentlySetBackendName(string* backend_name) {
@@ -156,9 +164,9 @@ Status BackendManager::GetCurrentlySetBackendName(string* backend_name) {
 
   // NGRAPH_TF_BACKEND is set
   string backend_env = std::string(ng_backend_env_value);
-  if (backend_env.empty() || !BackendManager::IsSupportedBackend(backend_env)) {
-    return errors::Internal("NGRAPH_TF_BACKEND: ", backend_env,
-                            " is not supported");
+  auto status = BackendManager::CanCreateBackend(backend_env);
+  if (status != Status::OK()) {
+    return errors::Internal("NGRAPH_TF_BACKEND: ", status.error_message());
   }
 
   *backend_name = backend_env;

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -54,7 +54,7 @@ Status BackendManager::CreateBackend(const string& backend_name) {
       bend_ptr = ng::runtime::Backend::create(backend_name);
     } catch (const std::exception& e) {
       return errors::Internal("Could not create backend of type ", backend_name,
-                              ". Got exception ", e.what());
+                              ". Got exception: ", e.what());
     }
 
     if (bend_ptr == nullptr) {

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -37,7 +37,7 @@ map<std::string, int> BackendManager::ref_count_each_backend_;
 Status BackendManager::SetBackendName(const string& backend_name) {
   std::lock_guard<std::mutex> lock(BackendManager::ng_backend_name_mutex_);
   auto status = BackendManager::CanCreateBackend(backend_name);
-  if (status != Status::OK()) {
+  if (!status.ok()) {
     return errors::Internal("Failed to set backend: ", status.error_message());
   }
   BackendManager::ng_backend_name_ = backend_name;
@@ -144,7 +144,7 @@ bool BackendManager::IsSupportedBackend(const string& backend_name) {
 
 Status BackendManager::CanCreateBackend(const string& backend_string) {
   auto status = BackendManager::CreateBackend(backend_string);
-  if (status == Status::OK()) {
+  if (status.ok()) {
     // The call to create backend increases the ref count
     // so releasing the backend here
     BackendManager::ReleaseBackend(backend_string);
@@ -165,7 +165,7 @@ Status BackendManager::GetCurrentlySetBackendName(string* backend_name) {
   // NGRAPH_TF_BACKEND is set
   string backend_env = std::string(ng_backend_env_value);
   auto status = BackendManager::CanCreateBackend(backend_env);
-  if (status != Status::OK()) {
+  if (!status.ok()) {
     return errors::Internal("NGRAPH_TF_BACKEND: ", status.error_message());
   }
 

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -133,15 +133,6 @@ size_t BackendManager::GetNumOfSupportedBackends() {
   return ng::runtime::BackendManager::get_registered_backends().size();
 }
 
-bool BackendManager::IsSupportedBackend(const string& backend_name) {
-  vector<string> registered_backends =
-      ng::runtime::BackendManager::get_registered_backends();
-  vector<string>::iterator itr = find(registered_backends.begin(),
-                                      registered_backends.end(), backend_name);
-
-  return itr != registered_backends.end();
-};
-
 Status BackendManager::CanCreateBackend(const string& backend_string) {
   auto status = BackendManager::CreateBackend(backend_string);
   if (status.ok()) {

--- a/ngraph_bridge/ngraph_backend_manager.h
+++ b/ngraph_bridge/ngraph_backend_manager.h
@@ -59,7 +59,9 @@ class BackendManager {
 
   // Returns True if the backend is supported
   // Searches the registered backends with nGraph to determine this
-  // Meant to find whether CPU, GPU is supported or not
+  // Meant to be used without device_id
+  // For eg. IsSupportedBackend("GPU") --> returns True
+  //         IsSupportedBackend("GPU:0") --> returns False
   static bool IsSupportedBackend(const string& backend_name);
 
   // Set the BackendManager backend ng_backend_name_
@@ -70,7 +72,9 @@ class BackendManager {
 
   // Tries to create a backend using the backend_string
   // which is a combination of backend_name:device_id
-  // Meant to check whether a backend with GPU:0 can be created or not
+  // Meant to check whether a backend (with or without device id)
+  // can be created or not
+  // For e.g CanCreateBackend("GPU") and CanCreateBackend("GPU:0")
   static Status CanCreateBackend(const string& backend_string);
 
   static void ReleaseBackend(const string& backend_name);

--- a/ngraph_bridge/ngraph_backend_manager.h
+++ b/ngraph_bridge/ngraph_backend_manager.h
@@ -57,9 +57,9 @@ class BackendManager {
   // Returns number of nGraph supported backends
   static size_t GetNumOfSupportedBackends();
 
-  // Returns True if the backend is supported or not
-  // Tries to create a backend with backend_name string to determine whether
-  // supported or not
+  // Returns True if the backend is supported
+  // Searches the registered backends with nGraph to determine this
+  // Meant to find whether CPU, GPU is supported or not
   static bool IsSupportedBackend(const string& backend_name);
 
   // Set the BackendManager backend ng_backend_name_
@@ -67,6 +67,11 @@ class BackendManager {
 
   // Creates backend of backend_name type
   static Status CreateBackend(const string& backend_name);
+
+  // Tries to create a backend using the backend_string
+  // which is a combination of backend_name:device_id
+  // Meant to check whether a backend with GPU:0 can be created or not
+  static Status CanCreateBackend(const string& backend_string);
 
   static void ReleaseBackend(const string& backend_name);
 

--- a/ngraph_bridge/ngraph_backend_manager.h
+++ b/ngraph_bridge/ngraph_backend_manager.h
@@ -57,13 +57,6 @@ class BackendManager {
   // Returns number of nGraph supported backends
   static size_t GetNumOfSupportedBackends();
 
-  // Returns True if the backend is supported
-  // Searches the list of backends registered with nGraph to determine this
-  // Meant to be used without device_id
-  // For eg. IsSupportedBackend("GPU") --> returns True
-  //         IsSupportedBackend("GPU:0") --> returns False
-  static bool IsSupportedBackend(const string& backend_name);
-
   // Set the BackendManager backend ng_backend_name_
   static Status SetBackendName(const string& backend_name);
 

--- a/python/ngraph_bridge/__init__.in.py
+++ b/python/ngraph_bridge/__init__.in.py
@@ -40,7 +40,7 @@ import ctypes
 
 __all__ = [
     'enable', 'disable', 'is_enabled', 'backends_len', 'list_backends',
-    'set_backend', 'is_supported_backend', 'get_currently_set_backend_name',
+    'set_backend', 'get_currently_set_backend_name',
     'start_logging_placement', 'stop_logging_placement',
     'is_logging_placement', '__version__', 'cxx11_abi_flag'
     'is_grappler_enabled', 'update_config', 'are_variables_enabled', 'set_disabled_ops', 'get_disabled_ops'
@@ -113,8 +113,6 @@ ngraph_bridge_lib.ngraph_is_enabled.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_list_backends.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_set_backend.argtypes = [ctypes.c_char_p]
 ngraph_bridge_lib.ngraph_set_backend.restype = ctypes.c_bool
-ngraph_bridge_lib.ngraph_is_supported_backend.argtypes = [ctypes.c_char_p]
-ngraph_bridge_lib.ngraph_is_supported_backend.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_get_currently_set_backend_name.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_is_logging_placement.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_tf_version.restype = ctypes.c_char_p
@@ -167,11 +165,6 @@ def list_backends():
 def set_backend(backend):
     if not ngraph_bridge_lib.ngraph_set_backend(backend.encode("utf-8")):
         raise Exception("Backend " + backend + " unavailable.")
-
-
-def is_supported_backend(backend):
-    return ngraph_bridge_lib.ngraph_is_supported_backend(
-        backend.encode("utf-8"))
 
 
 def get_currently_set_backend_name():

--- a/test/graph_rewrites/backend_manager_test.cc
+++ b/test/graph_rewrites/backend_manager_test.cc
@@ -112,6 +112,7 @@ TEST(BackendManager, GetCurrentlySetBackendName) {
 // Test CanCreateBackend
 TEST(BackendManager, CanCreateBackend) {
   ASSERT_OK(BackendManager::CanCreateBackend("CPU"));
+  ASSERT_OK(BackendManager::CanCreateBackend("CPU:0"));
   ASSERT_NOT_OK(BackendManager::CanCreateBackend("temp"));
   ASSERT_NOT_OK(BackendManager::CanCreateBackend(""));
 }

--- a/test/graph_rewrites/backend_manager_test.cc
+++ b/test/graph_rewrites/backend_manager_test.cc
@@ -109,6 +109,13 @@ TEST(BackendManager, GetCurrentlySetBackendName) {
   RestoreEnv(env_map);
 }
 
+// Test CanCreateBackend
+TEST(BackendManager, CanCreateBackend) {
+  ASSERT_OK(BackendManager::CanCreateBackend("CPU"));
+  ASSERT_NOT_OK(BackendManager::CanCreateBackend("temp"));
+  ASSERT_NOT_OK(BackendManager::CanCreateBackend(""));
+}
+
 // Test GetSupportedBackendNames
 TEST(BackendManager, GetSupportedBackendNames) {
   vector<string> ng_tf_backends = BackendManager::GetSupportedBackendNames();

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -202,21 +202,12 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
   int number_of_inputs = test_op->num_inputs();
 
   // Create nGraph backend
-  // If NGRAPH_TF_BACKEND is set create that backend
-  // Else create backend of type ng_backend_name
-  string ng_backend_type = ng_backend_name;
-  const char* ng_backend_env_value = std::getenv("NGRAPH_TF_BACKEND");
+  string ng_backend_type;
+  BackendManager::GetCurrentlySetBackendName(&ng_backend_type);
 
-  if (ng_backend_env_value != nullptr) {
-    string backend_env = std::string(ng_backend_env_value);
-    bool valid_ngraph_tf_backend =
-        !backend_env.empty() && BackendManager::IsSupportedBackend(backend_env);
-    ASSERT_TRUE(valid_ngraph_tf_backend) << "NGRAPH_TF_BACKEND " << backend_env
-                                         << " is not a supported backend";
-    ng_backend_type = backend_env;
+  if ((std::getenv("NGRAPH_TF_LOG_0_DISABLED") == nullptr)) {
+    NGRAPH_VLOG(0) << "NGraph using backend: " << ng_backend_type;
   }
-
-  NGRAPH_VLOG(5) << " Creating NG Backend " << ng_backend_type;
   BackendManager::CreateBackend(ng_backend_type);
   auto backend = BackendManager::GetBackend(ng_backend_type);
 

--- a/test/python/bfloat16/test_fusedbatchnorm_training_nchw.py
+++ b/test/python/bfloat16/test_fusedbatchnorm_training_nchw.py
@@ -25,9 +25,9 @@ import pytest
 np.random.seed(5)
 
 # Inputs
-scale = [1.0, 0.9, 1.1]
-offset = [0.1, 0.2, -.3]
-input_shape_nchw = [4, 3, 1, 2]
+scale = np.random.rand(channels)
+offset = np.random.rand(channels)
+input_shape_nchw = [4, channels, 1, 2]
 
 
 def tf_model():
@@ -57,7 +57,7 @@ config = tf.ConfigProto(
     log_device_placement=False,
     inter_op_parallelism_threads=1)
 
-k_np = np.random.rand(4, 3, 1, 2).astype('f')  # NCHW
+k_np = np.random.rand(*input_shape_nchw).astype('f')  # NCHW
 
 
 def test_fusedbatchnorm_nchw():

--- a/test/python/bfloat16/test_fusedbatchnorm_training_nchw.py
+++ b/test/python/bfloat16/test_fusedbatchnorm_training_nchw.py
@@ -25,8 +25,9 @@ import pytest
 np.random.seed(5)
 
 # Inputs
-scale = np.random.rand(channels)
-offset = np.random.rand(channels)
+channels = 32
+scale = np.random.rand(channels).astype('f')
+offset = np.random.rand(channels).astype('f')
 input_shape_nchw = [4, channels, 1, 2]
 
 

--- a/test/python/bfloat16/test_fusedbatchnorm_training_nhwc.py
+++ b/test/python/bfloat16/test_fusedbatchnorm_training_nhwc.py
@@ -26,8 +26,8 @@ np.random.seed(5)
 
 # Inputs
 channels = 32
-scale = np.random.rand(channels)
-offset = np.random.rand(channels)
+scale = np.random.rand(channels).astype('f')
+offset = np.random.rand(channels).astype('f')
 input_shape_nhwc = [4, 1, 2, channels]
 
 

--- a/test/python/bfloat16/test_fusedbatchnorm_training_nhwc.py
+++ b/test/python/bfloat16/test_fusedbatchnorm_training_nhwc.py
@@ -25,9 +25,10 @@ import pytest
 np.random.seed(5)
 
 # Inputs
-scale = [1.0, 0.9, 1.1]
-offset = [0.1, 0.2, -.3]
-input_shape_nhwc = [4, 1, 2, 3]
+channels = 32
+scale = np.random.rand(channels)
+offset = np.random.rand(channels)
+input_shape_nhwc = [4, 1, 2, channels]
 
 
 def tf_model():
@@ -54,7 +55,7 @@ config = tf.ConfigProto(
     log_device_placement=False,
     inter_op_parallelism_threads=1)
 
-k_np = np.random.rand(4, 1, 2, 3).astype('f')  # NHWC
+k_np = np.random.rand(*input_shape_nhwc).astype('f')  # NHWC
 
 
 def test_fusedbatchnorm_nhwc():

--- a/test/python/test_set_backend.py
+++ b/test/python/test_set_backend.py
@@ -58,7 +58,6 @@ class TestSetBackend(NgraphTest):
         out2 = tf.abs(out1)
 
         # set INTERPRETER backend
-        assert ngraph_bridge.is_supported_backend(backend_interpreter) == True
         ngraph_bridge.set_backend(backend_interpreter)
         currently_set_backend = ngraph_bridge.get_currently_set_backend_name()
         assert currently_set_backend == backend_interpreter
@@ -72,7 +71,6 @@ class TestSetBackend(NgraphTest):
         assert currently_set_backend == backend_interpreter
 
         # set CPU backend
-        assert ngraph_bridge.is_supported_backend(backend_cpu) == True
         ngraph_bridge.set_backend(backend_cpu)
         currently_set_backend = ngraph_bridge.get_currently_set_backend_name()
         assert currently_set_backend == backend_cpu

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -93,7 +93,7 @@ void SetNGraphTFBackend(const string& backend_name) {
   SetEnvVariable("NGRAPH_TF_BACKEND", backend_name);
 }
 
-// Generating Random Seed
+// Generating Seed for PseudoRandomNumberGenerator
 unsigned int GetSeedForRandomFunctions() {
   string env_name = "NGRAPH_TF_SEED";
   unsigned int seed = static_cast<unsigned>(time(0));

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -66,7 +66,7 @@ void SetEnvVariable(const string& env_var_name, const string& env_var_val) {
 }
 
 // Store/Restore Env Variables
-unordered_map<string, string> StoreEnv() {
+const unordered_map<string, string> StoreEnv() {
   unordered_map<string, string> env_map;
   string env_name = "NGRAPH_TF_BACKEND";
   if (IsEnvVariableSet(env_name)) {
@@ -85,7 +85,9 @@ void RestoreEnv(const unordered_map<string, string>& map) {
 // NGRAPH_TF_BACKEND related
 bool IsNGraphTFBackendSet() { return IsEnvVariableSet("NGRAPH_TF_BACKEND"); }
 
-string GetNGraphTFBackend() { return GetEnvVariable("NGRAPH_TF_BACKEND"); }
+const string GetNGraphTFBackend() {
+  return GetEnvVariable("NGRAPH_TF_BACKEND");
+}
 
 void UnsetNGraphTFBackend() { UnsetEnvVariable("NGRAPH_TF_BACKEND"); }
 
@@ -94,8 +96,8 @@ void SetNGraphTFBackend(const string& backend_name) {
 }
 
 // Generating Seed for PseudoRandomNumberGenerator
-unsigned int GetSeedForRandomFunctions() {
-  string env_name = "NGRAPH_TF_SEED";
+const unsigned int GetSeedForRandomFunctions() {
+  const string& env_name = "NGRAPH_TF_SEED";
   unsigned int seed = static_cast<unsigned>(time(0));
   if (!IsEnvVariableSet(env_name)) {
     NGRAPH_VLOG(5) << "Got seed " << seed;
@@ -106,12 +108,12 @@ unsigned int GetSeedForRandomFunctions() {
   try {
     int temp_seed = stoi(seedstr);
     if (temp_seed < 0) {
-      throw std::runtime_error{"Cannot set negative seed"};
+      throw std::invalid_argument{"Cannot set negative seed"};
     }
     seed = static_cast<unsigned>(temp_seed);
   } catch (const std::exception& exp) {
-    throw std::runtime_error{"Cannot set " + env_name + " with value " +
-                             seedstr + ", got exception " + exp.what()};
+    throw std::invalid_argument{"Cannot set " + env_name + " with value " +
+                                seedstr + ", got exception " + exp.what()};
   }
 
   NGRAPH_VLOG(5) << "Got seed from " << env_name << " : " << seed;

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -93,6 +93,27 @@ void SetNGraphTFBackend(const string& backend_name) {
   SetEnvVariable("NGRAPH_TF_BACKEND", backend_name);
 }
 
+// Generating Random Seed
+int GetSeedForRandomFunctions() {
+  string env_name = "NGRAPH_TF_SEED";
+  int seed = static_cast<unsigned>(time(0));
+  if (!IsEnvVariableSet(env_name)) {
+    NGRAPH_VLOG(5) << "Got seed " << seed;
+    return seed;
+  }
+
+  string seedstr = GetEnvVariable(env_name);
+  try {
+    seed = stoi(seedstr);
+  } catch (const std::exception& exp) {
+    throw std::runtime_error{"Cannot set " + env_name + " with value " +
+                             seedstr + " ,got exception " + exp.what()};
+  }
+
+  NGRAPH_VLOG(5) << "Got seed " << env_name << " : seed " << seed;
+  return seed;
+}
+
 // Input x will be used as an anchor
 // Actual value assigned equals to x * i
 void AssignInputValuesAnchor(Tensor& A, float x) {
@@ -107,7 +128,7 @@ void AssignInputValuesAnchor(Tensor& A, float x) {
 void AssignInputValuesRandom(Tensor& A) {
   auto A_flat = A.flat<float>();
   auto A_flat_data = A_flat.data();
-  srand(static_cast<unsigned>(time(0)));
+  srand(GetSeedForRandomFunctions());
   for (int i = 0; i < A_flat.size(); i++) {
     // give a number between 0 and 20
     float value =

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -94,9 +94,9 @@ void SetNGraphTFBackend(const string& backend_name) {
 }
 
 // Generating Random Seed
-int GetSeedForRandomFunctions() {
+unsigned int GetSeedForRandomFunctions() {
   string env_name = "NGRAPH_TF_SEED";
-  int seed = static_cast<unsigned>(time(0));
+  unsigned int seed = static_cast<unsigned>(time(0));
   if (!IsEnvVariableSet(env_name)) {
     NGRAPH_VLOG(5) << "Got seed " << seed;
     return seed;
@@ -104,10 +104,14 @@ int GetSeedForRandomFunctions() {
 
   string seedstr = GetEnvVariable(env_name);
   try {
-    seed = stoi(seedstr);
+    int temp_seed = stoi(seedstr);
+    if (temp_seed < 0) {
+      throw std::runtime_error{"Cannot set negative seed"};
+    }
+    seed = static_cast<unsigned>(temp_seed);
   } catch (const std::exception& exp) {
     throw std::runtime_error{"Cannot set " + env_name + " with value " +
-                             seedstr + " ,got exception " + exp.what()};
+                             seedstr + " ,got exception : " + exp.what()};
   }
 
   NGRAPH_VLOG(5) << "Got seed " << env_name << " : seed " << seed;

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -38,7 +38,7 @@ void ActivateNGraph();
 void DeactivateNGraph();
 
 // Store/Restore Env Variables
-unordered_map<string, string> StoreEnv();
+const unordered_map<string, string> StoreEnv();
 void RestoreEnv(const unordered_map<string, string>& map);
 
 // EnvVariable Utilities
@@ -49,7 +49,7 @@ void SetEnvVariable(const string& env_var_name, const string& env_var_val);
 
 // NGRAPH_TF_BACKEND related
 bool IsNGraphTFBackendSet();
-string GetNGraphTFBackend();
+const string GetNGraphTFBackend();
 void UnsetNGraphTFBackend();
 void SetNGraphTFBackend(const string& bname);
 
@@ -60,7 +60,7 @@ void PrintTensorAllValues(
     int64 max_entries);  // print max_entries of elements in the Tensor
 
 // Generating Random Seed
-unsigned int GetSeedForRandomFunctions();
+const unsigned int GetSeedForRandomFunctions();
 
 // Assignment Functions
 // TODO : Retire AssignInputValuesAnchor and AssignInputValuesRandom

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -60,7 +60,7 @@ void PrintTensorAllValues(
     int64 max_entries);  // print max_entries of elements in the Tensor
 
 // Generating Random Seed
-int GetSeedForRandomFunctions();
+unsigned int GetSeedForRandomFunctions();
 
 // Assignment Functions
 // TODO : Retire AssignInputValuesAnchor and AssignInputValuesRandom

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -59,6 +59,9 @@ void PrintTensorAllValues(
     const Tensor& T1,
     int64 max_entries);  // print max_entries of elements in the Tensor
 
+// Generating Random Seed
+int GetSeedForRandomFunctions();
+
 // Assignment Functions
 // TODO : Retire AssignInputValuesAnchor and AssignInputValuesRandom
 void AssignInputValuesAnchor(Tensor& A, float x);  // value assigned = x * index
@@ -92,7 +95,7 @@ template <typename T>
 void AssignInputValuesRandom(Tensor& A, T min, T max) {
   auto A_flat = A.flat<T>();
   auto A_flat_data = A_flat.data();
-  srand(static_cast<unsigned>(time(0)));
+  srand(GetSeedForRandomFunctions());
   for (int i = 0; i < A_flat.size(); i++) {
     T value =
         // randomly generate a number between 0 and (max-min) inclusive


### PR DESCRIPTION
- Added a new api CanCreateBackend.  
This api tries to create a backend with the full backend string (backend_type:device_id). Meant to be used to check for a valid backend before assigning it to the op. There is no user-facing api for this. It is meant for internal use alone
- IsSupportedBackend() is removed
- changed the parameters for fused_batchnorm_test
- created a env variable NGRAPH_TF_SEED to fix the seed for running tests, helps in debugging. Works only for C++ test. needs to extend to python tests. 
