### PR TITLE
Sarkars/some cleanup

### DIFF
--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -587,7 +587,7 @@ void NGraphEncapsulateImpl::ClearExecMaps() {
   m_executable_pipelined_tensors_map.clear();
 }
 
-Status NGraphEncapsulateImpl::Populate(
+Status NGraphEncapsulateImpl::GetPipelineIdxAndTensors(
     const std::shared_ptr<ngraph::runtime::Executable>& ng_exec,
     std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>& tpl) {
   if (GetExecCanCreateTensor()) {
@@ -607,6 +607,20 @@ Status NGraphEncapsulateImpl::Populate(
       return errors::Internal(
           "Expected GetTensorsFromPipeline to return an index >= 0, but got ",
           pipeline_idx);
+    }
+  }
+  return Status::OK();
+}
+
+Status NGraphEncapsulateImpl::ReturnPipelinedTensors(
+    std::shared_ptr<ngraph::runtime::Executable> ng_exec, size_t idx) {
+  if (GetExecCanCreateTensor()) {
+    try {
+      m_executable_pipelined_tensors_map.at(ng_exec).return_tensors(idx);
+    } catch (const std::exception& exp) {
+      return errors::Internal(
+          "Caught exception while returning pipelined tensors: ", exp.what(),
+          "\n");
     }
   }
   return Status::OK();

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -591,6 +591,8 @@ Status NGraphEncapsulateImpl::GetPipelineIdxAndTensors(
     const std::shared_ptr<ngraph::runtime::Executable>& ng_exec,
     std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>& tpl) {
   if (GetExecCanCreateTensor()) {
+    // Check if the pipelined tensors for this executable is created
+    // If not create and add them to the cache
     TF_RETURN_IF_ERROR(UpdatePipelinedTensorCache(ng_exec));
     // Cache must contain the ng_exec at this point
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -532,11 +532,11 @@ Status NGraphEncapsulateImpl::ParseNodeAttributes(
   return Status::OK();
 }
 
-Status NGraphEncapsulateImpl::CachePipelinedTensorIfNeeded(
+Status NGraphEncapsulateImpl::UpdatePipelinedTensorCache(
     std::shared_ptr<ngraph::runtime::Executable> ng_exec) {
   if (!m_executable_can_create_tensor) {
     return errors::Internal(
-        "CachePipelinedTensorIfNeeded called, but executable cannot create "
+        "UpdatePipelinedTensorCache called, but executable cannot create "
         "tensors");
   }
   auto itr = m_executable_pipelined_tensors_map.find(ng_exec);

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -579,6 +579,14 @@ NGraphEncapsulateImpl::GetTensorsFromPipeline(
   return out_tpl;
 }
 
+void NGraphEncapsulateImpl::ClearExecMaps() {
+  m_ng_exec_input_cache_map.clear();
+  m_ng_exec_output_cache_map.clear();
+  m_ng_exec_map.clear();
+  m_ng_function_map.clear();
+  m_executable_pipelined_tensors_map.clear();
+}
+
 }  // namespace ngraph_bridge
 
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -85,15 +85,15 @@ class NGraphEncapsulateImpl {
       const ng::element::Type& ng_element_type, const ng::Shape& ng_shape,
       std::shared_ptr<ng::runtime::Tensor> tensor_from_pipeline);
 
-  // Accessors(getters and setters) for the private data members of
-  // NgraphEncapsulateImpl class
-  // needed by NgraphEncapsulateOp class
+// Accessors(getters and setters) for the private data members of
+// NgraphEncapsulateImpl class
+// needed by NgraphEncapsulateOp class
 
-  #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
+#if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   const int& GetNumberOfCopies() { return number_of_copies; }
   void SetNumberOfCopies(const int& number) { number_of_copies = number; }
   int GetGraphId() { return m_graph_id; }
-  #endif
+#endif
 
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -146,8 +146,6 @@ class NGraphEncapsulateImpl {
     m_ng_exec_map[ng_map_key] = exec;
   }
 
-  void ClearNgExecMap() { m_ng_exec_map.clear(); }
-
   std::unordered_map<std::shared_ptr<ngraph::runtime::Executable>,
                      std::shared_ptr<ngraph::Function>>
   GetNgFunctionMap() {
@@ -160,7 +158,6 @@ class NGraphEncapsulateImpl {
     m_ng_function_map[exec] = function;
   }
 
-  void ClearNgFunctionMap() { m_ng_function_map.clear(); }
   // TODO:sindhu have another get function for output_cache which is only
   // readable
   std::vector<std::pair<void*, shared_ptr<ng::runtime::Tensor>>>&
@@ -174,10 +171,6 @@ class NGraphEncapsulateImpl {
           cache) {
     m_ng_exec_output_cache_map[exec] = cache;
   }
-
-  void ClearNgExecInputCache() { m_ng_exec_input_cache_map.clear(); }
-
-  void ClearNgExecOutputCache() { m_ng_exec_output_cache_map.clear(); }
 
   NGraphFreshnessTracker* GetNgraphFreshnessTracker() {
     return m_freshness_tracker;
@@ -196,10 +189,6 @@ class NGraphEncapsulateImpl {
 
   bool GetExecCanCreateTensor() { return m_executable_can_create_tensor; }
 
-  void ClearNgExecPipelinedTensorMap() {
-    m_executable_pipelined_tensors_map.clear();
-  }
-
   Status UpdatePipelinedTensorCache(
       std::shared_ptr<ngraph::runtime::Executable> ng_exec);
 
@@ -210,6 +199,8 @@ class NGraphEncapsulateImpl {
       std::shared_ptr<ngraph::runtime::Executable> ng_exec, size_t idx) {
     m_executable_pipelined_tensors_map.at(ng_exec).return_tensors(idx);
   }
+
+  void ClearExecMaps();
 
   // TF Graph for the cluster
   Graph m_graph;

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -87,11 +87,13 @@ class NGraphEncapsulateImpl {
 
   // Accessors(getters and setters) for the private data members of
   // NgraphEncapsulateImpl class
-  // needed by
-  // NgraphEncapsulateOp class
-  const int& GetNumberOfCopies() { return number_of_copies; }
+  // needed by NgraphEncapsulateOp class
 
+  #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
+  const int& GetNumberOfCopies() { return number_of_copies; }
   void SetNumberOfCopies(const int& number) { number_of_copies = number; }
+  int GetGraphId() { return m_graph_id; }
+  #endif
 
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -85,6 +85,26 @@ class NGraphEncapsulateImpl {
       const ng::element::Type& ng_element_type, const ng::Shape& ng_shape,
       std::shared_ptr<ng::runtime::Tensor> tensor_from_pipeline);
 
+  // Get pipeline index and input and output tensor groups from executable (if
+  // they can create tensors)
+  Status GetPipelineIdxAndTensors(
+      const std::shared_ptr<ngraph::runtime::Executable>&,
+      std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>&);
+
+  // Once done using, return the index to indicate that those executable created
+  // tensors are free for reuse
+  Status ReturnPipelinedTensors(std::shared_ptr<ngraph::runtime::Executable>,
+                                size_t);
+
+  // Clear all maps with ng_exec as keys
+  void ClearExecMaps();
+
+  // Parse additional attributes attached to the encapsulate node and filter out
+  // the ones needed for backend->SetConfig
+  Status ParseNodeAttributes(
+      const google::protobuf::Map<string, AttrValue>& additional_attributes,
+      std::unordered_map<std::string, std::string>* additional_attribute_map);
+
 // Accessors(getters and setters) for the private data members of
 // NgraphEncapsulateImpl class
 // needed by NgraphEncapsulateOp class
@@ -180,19 +200,7 @@ class NGraphEncapsulateImpl {
 
   void SetName(string name) { m_name = name; }
 
-  Status ParseNodeAttributes(
-      const google::protobuf::Map<string, AttrValue>& additional_attributes,
-      std::unordered_map<std::string, std::string>* additional_attribute_map);
   void SetExecCanCreateTensor(bool b) { m_executable_can_create_tensor = b; }
-
-  Status ReturnPipelinedTensors(std::shared_ptr<ngraph::runtime::Executable>,
-                                size_t);
-
-  Status GetPipelineIdxAndTensors(
-      const std::shared_ptr<ngraph::runtime::Executable>&,
-      std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>&);
-
-  void ClearExecMaps();
 
   // TF Graph for the cluster
   Graph m_graph;

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -93,6 +93,7 @@ class NGraphEncapsulateImpl {
   const int& GetNumberOfCopies() { return number_of_copies; }
   void SetNumberOfCopies(const int& number) { number_of_copies = number; }
   int GetGraphId() { return m_graph_id; }
+  void AppendCopyLog(const string str) { copy_log_str << str; }
 #endif
 
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
@@ -126,8 +127,6 @@ class NGraphEncapsulateImpl {
   void SetLogCopies(bool value) { log_copies = value; }
 
   const string GetCopyLog() { return copy_log_str.str(); }
-
-  void SetCopyLog(const string str) { copy_log_str.str() = str; }
 
   const std::vector<bool> GetStaticInputVector() { return m_input_is_static; }
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -93,16 +93,13 @@ class NGraphEncapsulateImpl {
   const int& GetNumberOfCopies() { return number_of_copies; }
   void SetNumberOfCopies(const int& number) { number_of_copies = number; }
   int GetGraphId() { return m_graph_id; }
+  void SetGraphId(const int& graph_id) { m_graph_id = graph_id; }
   void AppendCopyLog(const string str) { copy_log_str << str; }
 #endif
 
   const int& GetNgraphCluster() { return m_ngraph_cluster; }
 
   void SetNgraphCluster(const int& cluster) { m_ngraph_cluster = cluster; }
-
-  int GetGraphId() { return m_graph_id; }
-
-  void SetGraphId(const int& graph_id) { m_graph_id = graph_id; }
 
   const int& GetFunctionCache() { return my_function_cache_depth_in_items; }
 

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -185,21 +185,10 @@ class NGraphEncapsulateImpl {
       std::unordered_map<std::string, std::string>* additional_attribute_map);
   void SetExecCanCreateTensor(bool b) { m_executable_can_create_tensor = b; }
 
-  bool GetExecCanCreateTensor() { return m_executable_can_create_tensor; }
+  Status ReturnPipelinedTensors(std::shared_ptr<ngraph::runtime::Executable>,
+                                size_t);
 
-  Status UpdatePipelinedTensorCache(
-      std::shared_ptr<ngraph::runtime::Executable> ng_exec);
-
-  std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>
-  GetTensorsFromPipeline(std::shared_ptr<ngraph::runtime::Executable> ng_exec);
-
-  void ReturnPipelinedTensors(
-      std::shared_ptr<ngraph::runtime::Executable> ng_exec, size_t idx) {
-    m_executable_pipelined_tensors_map.at(ng_exec).return_tensors(idx);
-  }
-
-  // TODO: find better name
-  Status Populate(
+  Status GetPipelineIdxAndTensors(
       const std::shared_ptr<ngraph::runtime::Executable>&,
       std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>&);
 
@@ -249,6 +238,12 @@ class NGraphEncapsulateImpl {
       m_executable_pipelined_tensors_map;
 
   int m_depth{2};  // TODO make this settable
+
+  Status UpdatePipelinedTensorCache(
+      std::shared_ptr<ngraph::runtime::Executable> ng_exec);
+  std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>
+  GetTensorsFromPipeline(std::shared_ptr<ngraph::runtime::Executable> ng_exec);
+  bool GetExecCanCreateTensor() { return m_executable_can_create_tensor; }
 };
 
 }  // namespace ngraph_bridge

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -198,6 +198,11 @@ class NGraphEncapsulateImpl {
     m_executable_pipelined_tensors_map.at(ng_exec).return_tensors(idx);
   }
 
+  // TODO: find better name
+  Status Populate(
+      const std::shared_ptr<ngraph::runtime::Executable>&,
+      std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>&);
+
   void ClearExecMaps();
 
   // TF Graph for the cluster

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -200,7 +200,7 @@ class NGraphEncapsulateImpl {
     m_executable_pipelined_tensors_map.clear();
   }
 
-  Status CachePipelinedTensorIfNeeded(
+  Status UpdatePipelinedTensorCache(
       std::shared_ptr<ngraph::runtime::Executable> ng_exec);
 
   std::tuple<int, PipelinedTensorVector, PipelinedTensorVector>

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -108,9 +108,11 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
         ctx, ConvertGraphDefToGraph(opts, *graph_def, &ng_encap_impl_.m_graph));
   }
 
+#if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   int graph_id{-1};
   OP_REQUIRES_OK(ctx, ctx->GetAttr("ngraph_graph_id", &graph_id));
   ng_encap_impl_.SetGraphId(graph_id);
+#endif
   //
   // Initialize the "m_input_is_static" vector as follows:
   // (1) create m_input_is_static with n+1 elements, where n is the max arg

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -65,27 +65,27 @@ namespace ngraph_bridge {
 //---------------------------------------------------------------------------
 NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
     : OpKernel(ctx) {
-  ng_encap_impl.SetName(name());
+  ng_encap_impl_.SetName(name());
 
   std::ostringstream oss;
-  oss << "Encapsulate_" << ng_encap_impl.GetInstanceId() << ": " << name();
+  oss << "Encapsulate_" << ng_encap_impl_.GetInstanceId() << ": " << name();
 
   ngraph::Event event(oss.str(), name(), "");
 
-  NGRAPH_VLOG(1) << "NGraphEncapsulateOp: " << ng_encap_impl.GetInstanceId()
+  NGRAPH_VLOG(1) << "NGraphEncapsulateOp: " << ng_encap_impl_.GetInstanceId()
                  << " Name: " << name();
 
   GraphDef* graph_def;
 
   int cluster{-1};
   OP_REQUIRES_OK(ctx, ctx->GetAttr<int>("ngraph_cluster", &cluster));
-  ng_encap_impl.SetNgraphCluster(cluster);
+  ng_encap_impl_.SetNgraphCluster(cluster);
   graph_def =
-      NGraphClusterManager::GetClusterGraph(ng_encap_impl.GetNgraphCluster());
+      NGraphClusterManager::GetClusterGraph(ng_encap_impl_.GetNgraphCluster());
 
   if (graph_def == nullptr) {
     string flib_key =
-        "ngraph_cluster_" + to_string(ng_encap_impl.GetNgraphCluster());
+        "ngraph_cluster_" + to_string(ng_encap_impl_.GetNgraphCluster());
     // Read graphdef from function library
     const FunctionLibraryDefinition flib =
         *ctx->function_library()->GetFunctionLibraryDefinition();
@@ -100,17 +100,17 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
       return flib.LookUpOpDef(op, sig);
     };
     FunctionDefToBodyHelper(*fdef, {}, &flib, get_func_sig, &fnbody);
-    CopyGraph(*fnbody->graph, &ng_encap_impl.m_graph);
+    CopyGraph(*fnbody->graph, &ng_encap_impl_.m_graph);
   } else {
     GraphConstructorOptions opts;
     opts.allow_internal_ops = true;
     OP_REQUIRES_OK(
-        ctx, ConvertGraphDefToGraph(opts, *graph_def, &ng_encap_impl.m_graph));
+        ctx, ConvertGraphDefToGraph(opts, *graph_def, &ng_encap_impl_.m_graph));
   }
 
   int graph_id{-1};
   OP_REQUIRES_OK(ctx, ctx->GetAttr("ngraph_graph_id", &graph_id));
-  ng_encap_impl.SetGraphId(graph_id);
+  ng_encap_impl_.SetGraphId(graph_id);
   //
   // Initialize the "m_input_is_static" vector as follows:
   // (1) create m_input_is_static with n+1 elements, where n is the max arg
@@ -123,7 +123,7 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
   int32 max_arg_index = -1;
   std::vector<const Node*> arg_nodes;
 
-  for (auto node : ng_encap_impl.m_graph.nodes()) {
+  for (auto node : ng_encap_impl_.m_graph.nodes()) {
     if (node->type_string() == "_Arg") {
       arg_nodes.push_back(node);
 
@@ -134,10 +134,10 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
   }
 
   int size = max_arg_index + 1;
-  ng_encap_impl.ResizeStaticInputVector(size);
+  ng_encap_impl_.ResizeStaticInputVector(size);
 
   for (int i = 0; i < size; i++) {
-    ng_encap_impl.SetStaticInputVector(i, false);
+    ng_encap_impl_.SetStaticInputVector(i, false);
   }
 
   // Fill the vector.
@@ -161,7 +161,7 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
       }
     }
     NGRAPH_VLOG(5) << "Marking arg " << index << " is_static: " << is_static;
-    ng_encap_impl.SetStaticInputVector(index, is_static);
+    ng_encap_impl_.SetStaticInputVector(index, is_static);
   }
 
   // Set the backend type for the op
@@ -172,30 +172,30 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
   // Get the optional attributes
   std::unordered_map<std::string, std::string> additional_attribute_map;
   auto node_def = ctx->def();
-  OP_REQUIRES_OK(ctx, ng_encap_impl.ParseNodeAttributes(
+  OP_REQUIRES_OK(ctx, ng_encap_impl_.ParseNodeAttributes(
                           node_def.attr(), &additional_attribute_map));
 
   // Concatenate the backend_name:device_id
   try {
     string be_name =
         BackendManager::GetBackendCreationString(backend_name, device_id);
-    ng_encap_impl.SetOpBackend(be_name);
+    ng_encap_impl_.SetOpBackend(be_name);
   } catch (const std::exception& exp) {
     Status status = errors::Internal(
         "Caught exception while creating backend string ", exp.what(), "\n");
     OP_REQUIRES_OK(ctx, status);
   }
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Create backend " << def().name();
-  BackendManager::CreateBackend(ng_encap_impl.GetOpBackend());
+  BackendManager::CreateBackend(ng_encap_impl_.GetOpBackend());
   // SetConfig will be called for each EncapsulateOp
-  BackendManager::SetConfig(ng_encap_impl.GetOpBackend(),
+  BackendManager::SetConfig(ng_encap_impl_.GetOpBackend(),
                             additional_attribute_map);
 
-  ng_encap_impl.SetExecCanCreateTensor(
-      BackendManager::GetBackend(ng_encap_impl.GetOpBackend())
+  ng_encap_impl_.SetExecCanCreateTensor(
+      BackendManager::GetBackend(ng_encap_impl_.GetOpBackend())
           ->executable_can_create_tensors());
   NGRAPH_VLOG(5) << "Executable can "
-                 << (ng_encap_impl.GetExecCanCreateTensor() ? "" : "not")
+                 << (ng_encap_impl_.GetExecCanCreateTensor() ? "" : "not")
                  << " create tensors";
 
   event.Stop();
@@ -207,16 +207,16 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
 //---------------------------------------------------------------------------
 NGraphEncapsulateOp::~NGraphEncapsulateOp() {
   std::ostringstream oss;
-  oss << "Destroy Encapsulate_" << ng_encap_impl.GetInstanceId() << ": "
+  oss << "Destroy Encapsulate_" << ng_encap_impl_.GetInstanceId() << ": "
       << name();
   ngraph::Event event(oss.str(), name(), "");
   NGRAPH_VLOG(2) << "~NGraphEncapsulateOp::" << name();
   // If the kernel goes away, we must de-register all of its cached
   // functions
   // from the freshness tracker.
-  if (ng_encap_impl.GetNgraphFreshnessTracker() != nullptr) {
-    for (auto kv : ng_encap_impl.GetNgExecMap()) {
-      ng_encap_impl.GetNgraphFreshnessTracker()->RemoveUser(kv.second);
+  if (ng_encap_impl_.GetNgraphFreshnessTracker() != nullptr) {
+    for (auto kv : ng_encap_impl_.GetNgExecMap()) {
+      ng_encap_impl_.GetNgraphFreshnessTracker()->RemoveUser(kv.second);
     }
 
     // TODO(amprocte): We should be able to unref the tracker here, but it
@@ -227,9 +227,9 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   // Remove Entries from Catalog
   // Remove entries related to outputs
-  for (int i = 0; i < ng_encap_impl.GetNumberOfOutputs(); i++) {
+  for (int i = 0; i < ng_encap_impl_.GetNumberOfOutputs(); i++) {
     string key =
-        NGraphCatalog::CreateNodeKey(ng_encap_impl.GetGraphId(), name(), i);
+        NGraphCatalog::CreateNodeKey(ng_encap_impl_.GetGraphId(), name(), i);
     if (NGraphCatalog::ExistsInEncapOutputInfoMap(key)) {
       NGraphCatalog::DeleteFromEncapOutputInfoMap(key);
       NGRAPH_VLOG(2) << "Deleting from output info map " << key;
@@ -237,13 +237,13 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
   }
 
   NGRAPH_VLOG(2) << "Deleting from Output Copy Index map " << name();
-  NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(ng_encap_impl.GetGraphId(),
+  NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(ng_encap_impl_.GetGraphId(),
                                                      name());
 
   // Remove entries related to inputs
-  for (int i = 0; i < ng_encap_impl.GetNumberOfOutputs(); i++) {
+  for (int i = 0; i < ng_encap_impl_.GetNumberOfOutputs(); i++) {
     string key =
-        NGraphCatalog::CreateNodeKey(ng_encap_impl.GetGraphId(), name(), i);
+        NGraphCatalog::CreateNodeKey(ng_encap_impl_.GetGraphId(), name(), i);
     if (NGraphCatalog::ExistsInInputVariableSharedNameMap(key)) {
       NGraphCatalog::DeleteFromInputVariableSharedNameMap(key);
       NGRAPH_VLOG(2) << "Deleting from input variable shared name map " << key;
@@ -252,15 +252,15 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
 
 #endif
 
-  ng_encap_impl.ClearNgExecInputCache();
-  ng_encap_impl.ClearNgExecOutputCache();
-  ng_encap_impl.ClearNgExecMap();
-  ng_encap_impl.ClearNgFunctionMap();
-  ng_encap_impl.ClearNgExecPipelinedTensorMap();
+  ng_encap_impl_.ClearNgExecInputCache();
+  ng_encap_impl_.ClearNgExecOutputCache();
+  ng_encap_impl_.ClearNgExecMap();
+  ng_encap_impl_.ClearNgFunctionMap();
+  ng_encap_impl_.ClearNgExecPipelinedTensorMap();
 
   // Release the backend
   NGRAPH_VLOG(2) << "~NGraphEncapsulateOp():: ReleaseBackend";
-  BackendManager::ReleaseBackend(ng_encap_impl.GetOpBackend());
+  BackendManager::ReleaseBackend(ng_encap_impl_.GetOpBackend());
   event.Stop();
   ngraph::Event::write_trace(event);
 }
@@ -270,14 +270,14 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
 //---------------------------------------------------------------------------
 void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   std::ostringstream oss;
-  oss << "Execute: Encapsulate_" << ng_encap_impl.GetInstanceId() << ": "
+  oss << "Execute: Encapsulate_" << ng_encap_impl_.GetInstanceId() << ": "
       << name();
   ngraph::Event event(oss.str(), name(), "");
 
   Timer compute_time;
   std::lock_guard<std::mutex> lock(m_compute_lock);
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute starting for cluster "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
 
   ngraph::Event event_func_maybe_create("FunctionMaybeCreate", name(), "");
   Timer function_lookup_or_create;
@@ -298,33 +298,33 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   int step_id = ctx->step_id();
 
   // Get ngraph executable and inputs information
-  OP_REQUIRES_OK(ctx, ng_encap_impl.GetNgExecutable(
+  OP_REQUIRES_OK(ctx, ng_encap_impl_.GetNgExecutable(
                           tf_input_tensors, input_shapes, static_input_map,
                           op_backend, ng_exec));
 
   NGRAPH_VLOG(1) << " Step_ID: " << step_id;
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute got ngraph executable for cluster "
-      << ng_encap_impl.GetNgraphCluster();
+      << ng_encap_impl_.GetNgraphCluster();
 
   int time_func_create_or_lookup = function_lookup_or_create.ElapsedInMS();
   event_func_maybe_create.Stop();
 
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute got graph for cluster "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
 
   Timer create_or_lookup_tensors;
 
   int pipeline_idx = -1;
   PipelinedTensorVector inp_group_from_pipeline;
   PipelinedTensorVector out_group_from_pipeline;
-  if (ng_encap_impl.GetExecCanCreateTensor()) {
-    OP_REQUIRES_OK(ctx, ng_encap_impl.CachePipelinedTensorIfNeeded(ng_exec));
+  if (ng_encap_impl_.GetExecCanCreateTensor()) {
+    OP_REQUIRES_OK(ctx, ng_encap_impl_.CachePipelinedTensorIfNeeded(ng_exec));
     // Cache must contain the ng_exec at this point
 
     try {
       std::tie(pipeline_idx, inp_group_from_pipeline, out_group_from_pipeline) =
-          ng_encap_impl.GetTensorsFromPipeline(ng_exec);
+          ng_encap_impl_.GetTensorsFromPipeline(ng_exec);
     } catch (const std::exception& exp) {
       OP_REQUIRES(
           ctx, false,
@@ -340,7 +340,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     }
   }
 
-  if (ng_encap_impl.GetNgraphFreshnessTracker() == nullptr) {
+  if (ng_encap_impl_.GetNgraphFreshnessTracker() == nullptr) {
     auto creator = [](NGraphFreshnessTracker** tracker) {
       *tracker = new NGraphFreshnessTracker();
       return Status::OK();
@@ -350,12 +350,12 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ctx, ctx->resource_manager()->LookupOrCreate<NGraphFreshnessTracker>(
                  ctx->resource_manager()->default_container(),
                  "ngraph_freshness_tracker", &set_tracker, creator));
-    ng_encap_impl.SetNgraphFreshnessTracker(set_tracker);
+    ng_encap_impl_.SetNgraphFreshnessTracker(set_tracker);
   }
 
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute got freshness tracker for cluster "
-      << ng_encap_impl.GetNgraphCluster();
+      << ng_encap_impl_.GetNgraphCluster();
 
   // Allocate tensors for input arguments.
   ngraph::Event event_alloc_input("Input: maybe create", name(), "");
@@ -363,7 +363,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   vector<shared_ptr<ng::runtime::Tensor>> ng_inputs;
   int ng_input_tensor_size_in_bytes = 0;
 
-  OP_REQUIRES_OK(ctx, ng_encap_impl.AllocateNGInputTensors(
+  OP_REQUIRES_OK(ctx, ng_encap_impl_.AllocateNGInputTensors(
                           tf_input_tensors, ng_exec, inp_group_from_pipeline,
                           op_backend, ng_inputs));
 
@@ -371,7 +371,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute allocated argument tensors "
                     "for cluster "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
   // Allocate tensors for the output results.
   ngraph::Event event_alloc_output("Output: maybe create", name(), "");
   vector<shared_ptr<ng::runtime::Tensor>> ng_outputs;
@@ -405,21 +405,21 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
                          "the element type expected by TensorFlow"));
   }
 
-  OP_REQUIRES_OK(ctx, ng_encap_impl.AllocateNGOutputTensors(
+  OP_REQUIRES_OK(ctx, ng_encap_impl_.AllocateNGOutputTensors(
                           tf_output_tensors, ng_exec, out_group_from_pipeline,
                           op_backend, ng_outputs));
-  auto output_caches = ng_encap_impl.GetNgExecOutputCacheMap(ng_exec);
+  auto output_caches = ng_encap_impl_.GetNgExecOutputCacheMap(ng_exec);
 
   event_alloc_output.Stop();
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute allocated result tensors for cluster "
-      << ng_encap_impl.GetNgraphCluster();
+      << ng_encap_impl_.GetNgraphCluster();
 
 // Dealing with the output from Variable nodes here
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute getting output variables "
                     "from resource manager "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
 
   ngraph::Event event_output_check_in_catalog(
       "Get Variable Outputs from Resource Manager", name(), "");
@@ -430,7 +430,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     // if the output tensor is going to be assigned to a variable
     // we ask nGraph to provide the output directly in the variable tensor
     bool ref_exists = NGraphCatalog::ExistsInEncapOutputInfoMap(
-        ng_encap_impl.GetGraphId(), name(), i);
+        ng_encap_impl_.GetGraphId(), name(), i);
     if (!ref_exists) {
       OP_REQUIRES(ctx, ng_outputs[i] != nullptr,
                   errors::Internal("Output ", i,
@@ -438,7 +438,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       continue;
     }
     string output_key =
-        NGraphCatalog::CreateNodeKey(ng_encap_impl.GetGraphId(), name(), i);
+        NGraphCatalog::CreateNodeKey(ng_encap_impl_.GetGraphId(), name(), i);
     string ref_var_name =
         NGraphCatalog::GetVariableSharedNameFromEncapOutputInfoMap(output_key);
     NGraphVar* var;
@@ -462,7 +462,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute getting input variables "
                     "from resource manager "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
 
   ngraph::Event event_input_check_in_catalog(
       "Get Variable Inputs from Resource Manager", name(), "");
@@ -470,7 +470,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   // Dealing with the input from Variable nodes here
   for (int input_index = 0; input_index < input_shapes.size(); input_index++) {
     bool ref_exists = NGraphCatalog::ExistsInInputVariableSharedNameMap(
-        ng_encap_impl.GetGraphId(), def().name(), input_index);
+        ng_encap_impl_.GetGraphId(), def().name(), input_index);
 
     if (!ref_exists) {
       OP_REQUIRES(ctx, ng_inputs[input_index] != nullptr,
@@ -480,22 +480,22 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     }
 
     string ref_var_name = NGraphCatalog::GetInputVariableSharedName(
-        ng_encap_impl.GetGraphId(), def().name(), input_index);
+        ng_encap_impl_.GetGraphId(), def().name(), input_index);
     NGraphVar* var;
     OP_REQUIRES_OK(ctx, ctx->resource_manager()->Lookup<NGraphVar>(
                             ctx->resource_manager()->default_container(),
                             ref_var_name, &var));
 
     if (var->sync_ng_tensor()) {
-      int copies = ng_encap_impl.GetNumberOfCopies();
-      ng_encap_impl.SetNumberOfCopies(copies++);
+      int copies = ng_encap_impl_.GetNumberOfCopies();
+      ng_encap_impl_.SetNumberOfCopies(copies++);
       stringstream str;
       str << "Var_Sync[" << input_index << "] ";
-      ng_encap_impl.SetCopyLog(str.str());
+      ng_encap_impl_.SetCopyLog(str.str());
     }
 
     void* current_tf_ptr = (void*)DMAHelper::base(&ctx->input(input_index));
-    bool is_stale = !ng_encap_impl.GetNgraphFreshnessTracker()->IsFresh(
+    bool is_stale = !ng_encap_impl_.GetNgraphFreshnessTracker()->IsFresh(
         current_tf_ptr, ng_exec);
     var->ng_tensor()->set_stale(is_stale);
     ng_inputs[input_index] = var->ng_tensor();
@@ -513,14 +513,14 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   ngraph::Event event_execute_function("Execute nGraph", name(), "");
   Timer execute_function;
   {
-    BackendManager::LockBackend(ng_encap_impl.GetOpBackend());
+    BackendManager::LockBackend(ng_encap_impl_.GetOpBackend());
     NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute call starting for cluster "
-                   << ng_encap_impl.GetNgraphCluster();
+                   << ng_encap_impl_.GetNgraphCluster();
     try {
       ng_exec->call(ng_outputs, ng_inputs);
     } catch (const std::exception& exp) {
-      ng_function = ng_encap_impl.GetNgFunctionMap()[ng_exec];
-      BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
+      ng_function = ng_encap_impl_.GetNgFunctionMap()[ng_exec];
+      BackendManager::UnlockBackend(ng_encap_impl_.GetOpBackend());
       NgraphSerialize("tf_function_error_" + ctx->op_kernel().name() + ".json",
                       ng_function);
       OP_REQUIRES(ctx, false,
@@ -528,15 +528,15 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
                       "Caught exception while executing nGraph computation: ",
                       exp.what(), "\n"));
     } catch (...) {
-      ng_function = ng_encap_impl.GetNgFunctionMap()[ng_exec];
-      BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
+      ng_function = ng_encap_impl_.GetNgFunctionMap()[ng_exec];
+      BackendManager::UnlockBackend(ng_encap_impl_.GetOpBackend());
       NgraphSerialize("tf_function_error_" + ctx->op_kernel().name() + ".json",
                       ng_function);
       OP_REQUIRES(
           ctx, false,
           errors::Internal("Error in executing the nGraph computation\n"));
     }
-    BackendManager::UnlockBackend(ng_encap_impl.GetOpBackend());
+    BackendManager::UnlockBackend(ng_encap_impl_.GetOpBackend());
   }
   int time_execute_function = execute_function.ElapsedInMS();
   event_execute_function.Stop();
@@ -544,7 +544,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   long vm, rss;
   MemoryProfile(vm, rss);
   NGRAPH_VLOG(1) << "NGRAPH_TF_MEM_PROFILE:  OP_ID: "
-                 << ng_encap_impl.GetInstanceId() << " Step_ID: " << step_id
+                 << ng_encap_impl_.GetInstanceId() << " Step_ID: " << step_id
                  << " Cluster: " << name() << " Input Tensors created: "
                  << ng_input_tensor_size_in_bytes / (1024 * 1024) << " MB"
                  << " Output Tensors created: "
@@ -552,7 +552,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
                  << " Total process memory: " << rss / (1024 * 1024) << " GB";
 
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute call done for cluster "
-                 << ng_encap_impl.GetNgraphCluster();
+                 << ng_encap_impl_.GetNgraphCluster();
 
   // Copy value to host if backend is not CPU
   ngraph::Event event_copy_output("Output - copy back", name(), "");
@@ -562,16 +562,16 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     size_t output_tensor_count = output_caches.size();
     std::vector<std::unique_ptr<ngraph::Event>> output_copy_events;
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
-    if (ng_encap_impl.GetNumberOfOutputs() == -1) {
+    if (ng_encap_impl_.GetNumberOfOutputs() == -1) {
       NGRAPH_VLOG(4) << "Settig number of outputs for " << def().name();
-      ng_encap_impl.SetNumberOfOutputs(ng_outputs.size());
+      ng_encap_impl_.SetNumberOfOutputs(ng_outputs.size());
       NGRAPH_VLOG(4) << "Setting number of inputs for " << def().name();
-      ng_encap_impl.SetNumberOfInputs(ng_inputs.size());
+      ng_encap_impl_.SetNumberOfInputs(ng_inputs.size());
     }
     for (size_t i = 0; i < output_tensor_count; ++i) {
       // Sync the Var Tensor if required
       string output_key = NGraphCatalog::CreateNodeKey(
-          ng_encap_impl.GetGraphId(), def().name(), i);
+          ng_encap_impl_.GetGraphId(), def().name(), i);
       bool ref_exists = NGraphCatalog::ExistsInEncapOutputInfoMap(output_key);
 
       if (ref_exists) {
@@ -588,14 +588,14 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
         if (NGraphCatalog::GetCopyToTFFromEncapOutputInfoMap(output_key)) {
           if (var->copy_ng_to_tf()) {
-            int copies = ng_encap_impl.GetNumberOfCopies();
-            ng_encap_impl.SetNumberOfCopies(copies++);
-            ng_encap_impl.SetCopyLog(" COPY_TO_TF ");
+            int copies = ng_encap_impl_.GetNumberOfCopies();
+            ng_encap_impl_.SetNumberOfCopies(copies++);
+            ng_encap_impl_.SetCopyLog(" COPY_TO_TF ");
           }
           if (!NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(
                   output_key)) {
             // Some tf op might update the ng-tensor value so mark it stale
-            ng_encap_impl.SetCopyLog(" SET_SYNC ");
+            ng_encap_impl_.SetCopyLog(" SET_SYNC ");
             var->set_sync_ng_tensor(true);
           }
         }
@@ -606,14 +606,14 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       void* dst_ptr;
       std::tie(dst_ptr, dst_ng_tensor) = output_caches[i];
 
-      if (ng_encap_impl.GetOpBackend() != "CPU" &&
-          NGraphCatalog::EncapOutputIndexNeedsCopy(ng_encap_impl.GetGraphId(),
+      if (ng_encap_impl_.GetOpBackend() != "CPU" &&
+          NGraphCatalog::EncapOutputIndexNeedsCopy(ng_encap_impl_.GetGraphId(),
                                                    def().name(), i)) {
-        int copies = ng_encap_impl.GetNumberOfCopies();
-        ng_encap_impl.SetNumberOfCopies(copies++);
+        int copies = ng_encap_impl_.GetNumberOfCopies();
+        ng_encap_impl_.SetNumberOfCopies(copies++);
         stringstream log;
         log << " COPY_OP_VAL[" << i << "]";
-        ng_encap_impl.SetCopyLog(log.str());
+        ng_encap_impl_.SetCopyLog(log.str());
 
         NGRAPH_VLOG(4) << "Copying Output " << def().name() << " ,index: " << i;
         auto ng_element_type = dst_ng_tensor->get_element_type();
@@ -630,7 +630,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       }
     }
 #else
-    if (ng_encap_impl.GetOpBackend() != "CPU") {
+    if (ng_encap_impl_.GetOpBackend() != "CPU") {
       for (size_t i = 0; i < output_tensor_count; ++i) {
         void* dst_ptr;
         std::shared_ptr<ng::runtime::Tensor> dst_ng_tensor;
@@ -665,10 +665,10 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   std::stringstream str;
-  str << " Number of copies " << ng_encap_impl.GetNumberOfCopies() << "\n";
-  ng_encap_impl.SetCopyLog(str.str());
-  if (ng_encap_impl.GetLogCopies()) {
-    cout << ng_encap_impl.GetCopyLog();
+  str << " Number of copies " << ng_encap_impl_.GetNumberOfCopies() << "\n";
+  ng_encap_impl_.SetCopyLog(str.str());
+  if (ng_encap_impl_.GetLogCopies()) {
+    cout << ng_encap_impl_.GetCopyLog();
   }
 #endif
 
@@ -677,14 +677,14 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   // iteration if this encapsulate finds the tensor fresh, then it will use it
   for (int i = 0; i < input_shapes.size(); i++) {
     void* src_ptr = (void*)DMAHelper::base(&ctx->input(i));
-    ng_encap_impl.GetNgraphFreshnessTracker()->MarkFresh(src_ptr, ng_exec);
+    ng_encap_impl_.GetNgraphFreshnessTracker()->MarkFresh(src_ptr, ng_exec);
   }
   int time_copy_output_tensors_to_host =
       copy_output_tensors_to_host.ElapsedInMS();
 
-  if (ng_encap_impl.GetExecCanCreateTensor()) {
+  if (ng_encap_impl_.GetExecCanCreateTensor()) {
     try {
-      ng_encap_impl.ReturnPipelinedTensors(ng_exec, pipeline_idx);
+      ng_encap_impl_.ReturnPipelinedTensors(ng_exec, pipeline_idx);
     } catch (const std::exception& exp) {
       OP_REQUIRES(ctx, false,
                   errors::Internal(
@@ -695,9 +695,9 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute done marking fresh for cluster "
-      << ng_encap_impl.GetNgraphCluster();
+      << ng_encap_impl_.GetNgraphCluster();
   NGRAPH_VLOG(1) << "NGRAPH_TF_TIMING_PROFILE: OP_ID: "
-                 << ng_encap_impl.GetInstanceId() << " Step_ID: " << step_id
+                 << ng_encap_impl_.GetInstanceId() << " Step_ID: " << step_id
                  << " Cluster: " << name()
                  << " Time-Compute: " << compute_time.ElapsedInMS()
                  << " Function-Create-or-Lookup: " << time_func_create_or_lookup

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -252,11 +252,7 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
 
 #endif
 
-  ng_encap_impl_.ClearNgExecInputCache();
-  ng_encap_impl_.ClearNgExecOutputCache();
-  ng_encap_impl_.ClearNgExecMap();
-  ng_encap_impl_.ClearNgFunctionMap();
-  ng_encap_impl_.ClearNgExecPipelinedTensorMap();
+  ng_encap_impl_.ClearExecMaps();
 
   // Release the backend
   NGRAPH_VLOG(2) << "~NGraphEncapsulateOp():: ReleaseBackend";

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -487,7 +487,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       ng_encap_impl_.SetNumberOfCopies(copies++);
       stringstream str;
       str << "Var_Sync[" << input_index << "] ";
-      ng_encap_impl_.SetCopyLog(str.str());
+      ng_encap_impl_.AppendCopyLog(str.str());
     }
 
     void* current_tf_ptr = (void*)DMAHelper::base(&ctx->input(input_index));
@@ -586,12 +586,12 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
           if (var->copy_ng_to_tf()) {
             int copies = ng_encap_impl_.GetNumberOfCopies();
             ng_encap_impl_.SetNumberOfCopies(copies++);
-            ng_encap_impl_.SetCopyLog(" COPY_TO_TF ");
+            ng_encap_impl_.AppendCopyLog(" COPY_TO_TF ");
           }
           if (!NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(
                   output_key)) {
             // Some tf op might update the ng-tensor value so mark it stale
-            ng_encap_impl_.SetCopyLog(" SET_SYNC ");
+            ng_encap_impl_.AppendCopyLog(" SET_SYNC ");
             var->set_sync_ng_tensor(true);
           }
         }
@@ -609,7 +609,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ng_encap_impl_.SetNumberOfCopies(copies++);
         stringstream log;
         log << " COPY_OP_VAL[" << i << "]";
-        ng_encap_impl_.SetCopyLog(log.str());
+        ng_encap_impl_.AppendCopyLog(log.str());
 
         NGRAPH_VLOG(4) << "Copying Output " << def().name() << " ,index: " << i;
         auto ng_element_type = dst_ng_tensor->get_element_type();
@@ -662,7 +662,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 #if defined(NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS)
   std::stringstream str;
   str << " Number of copies " << ng_encap_impl_.GetNumberOfCopies() << "\n";
-  ng_encap_impl_.SetCopyLog(str.str());
+  ng_encap_impl_.AppendCopyLog(str.str());
   if (ng_encap_impl_.GetLogCopies()) {
     cout << ng_encap_impl_.GetCopyLog();
   }

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -237,8 +237,8 @@ NGraphEncapsulateOp::~NGraphEncapsulateOp() {
   }
 
   NGRAPH_VLOG(2) << "Deleting from Output Copy Index map " << name();
-  NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(ng_encap_impl_.GetGraphId(),
-                                                     name());
+  NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(
+      ng_encap_impl_.GetGraphId(), name());
 
   // Remove entries related to inputs
   for (int i = 0; i < ng_encap_impl_.GetNumberOfOutputs(); i++) {

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -319,7 +319,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   PipelinedTensorVector inp_group_from_pipeline;
   PipelinedTensorVector out_group_from_pipeline;
   if (ng_encap_impl_.GetExecCanCreateTensor()) {
-    OP_REQUIRES_OK(ctx, ng_encap_impl_.CachePipelinedTensorIfNeeded(ng_exec));
+    OP_REQUIRES_OK(ctx, ng_encap_impl_.UpdatePipelinedTensorCache(ng_exec));
     // Cache must contain the ng_exec at this point
 
     try {

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -275,7 +275,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   ngraph::Event event(oss.str(), name(), "");
 
   Timer compute_time;
-  std::lock_guard<std::mutex> lock(m_compute_lock);
+  std::lock_guard<std::mutex> lock(compute_lock_);
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute starting for cluster "
                  << ng_encap_impl_.GetNgraphCluster();
 

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -316,25 +316,35 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   int pipeline_idx = -1;
   PipelinedTensorVector inp_group_from_pipeline;
   PipelinedTensorVector out_group_from_pipeline;
-  if (ng_encap_impl_.GetExecCanCreateTensor()) {
-    OP_REQUIRES_OK(ctx, ng_encap_impl_.UpdatePipelinedTensorCache(ng_exec));
-    // Cache must contain the ng_exec at this point
 
-    try {
-      std::tie(pipeline_idx, inp_group_from_pipeline, out_group_from_pipeline) =
-          ng_encap_impl_.GetTensorsFromPipeline(ng_exec);
-    } catch (const std::exception& exp) {
-      OP_REQUIRES(
-          ctx, false,
-          errors::Internal("Caught exception while getting pipelined tensors: ",
-                           exp.what(), "\n"));
-    }
+  if (true) {
+    std::tuple<int, PipelinedTensorVector, PipelinedTensorVector> tmp_tpl;
+    OP_REQUIRES_OK(ctx, ng_encap_impl_.Populate(ng_exec, tmp_tpl));
+    std::tie(pipeline_idx, inp_group_from_pipeline, out_group_from_pipeline) =
+        tmp_tpl;
 
-    if (pipeline_idx < 0) {
-      OP_REQUIRES(ctx, false,
-                  errors::Internal("Expected GetTensorsFromPipeline to return "
-                                   "an index >= 0, but got ",
-                                   pipeline_idx));
+  } else {
+    if (ng_encap_impl_.GetExecCanCreateTensor()) {
+      OP_REQUIRES_OK(ctx, ng_encap_impl_.UpdatePipelinedTensorCache(ng_exec));
+      // Cache must contain the ng_exec at this point
+
+      try {
+        std::tie(pipeline_idx, inp_group_from_pipeline,
+                 out_group_from_pipeline) =
+            ng_encap_impl_.GetTensorsFromPipeline(ng_exec);
+      } catch (const std::exception& exp) {
+        OP_REQUIRES(ctx, false,
+                    errors::Internal(
+                        "Caught exception while getting pipelined tensors: ",
+                        exp.what(), "\n"));
+      }
+
+      if (pipeline_idx < 0) {
+        OP_REQUIRES(ctx, false, errors::Internal(
+                                    "Expected GetTensorsFromPipeline to return "
+                                    "an index >= 0, but got ",
+                                    pipeline_idx));
+      }
     }
   }
 

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -317,36 +317,10 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   PipelinedTensorVector inp_group_from_pipeline;
   PipelinedTensorVector out_group_from_pipeline;
 
-  if (true) {
-    std::tuple<int, PipelinedTensorVector, PipelinedTensorVector> tmp_tpl;
-    OP_REQUIRES_OK(ctx, ng_encap_impl_.Populate(ng_exec, tmp_tpl));
-    std::tie(pipeline_idx, inp_group_from_pipeline, out_group_from_pipeline) =
-        tmp_tpl;
-
-  } else {
-    if (ng_encap_impl_.GetExecCanCreateTensor()) {
-      OP_REQUIRES_OK(ctx, ng_encap_impl_.UpdatePipelinedTensorCache(ng_exec));
-      // Cache must contain the ng_exec at this point
-
-      try {
-        std::tie(pipeline_idx, inp_group_from_pipeline,
-                 out_group_from_pipeline) =
-            ng_encap_impl_.GetTensorsFromPipeline(ng_exec);
-      } catch (const std::exception& exp) {
-        OP_REQUIRES(ctx, false,
-                    errors::Internal(
-                        "Caught exception while getting pipelined tensors: ",
-                        exp.what(), "\n"));
-      }
-
-      if (pipeline_idx < 0) {
-        OP_REQUIRES(ctx, false, errors::Internal(
-                                    "Expected GetTensorsFromPipeline to return "
-                                    "an index >= 0, but got ",
-                                    pipeline_idx));
-      }
-    }
-  }
+  std::tuple<int, PipelinedTensorVector, PipelinedTensorVector> tmp_tpl;
+  OP_REQUIRES_OK(ctx, ng_encap_impl_.Populate(ng_exec, tmp_tpl));
+  std::tie(pipeline_idx, inp_group_from_pipeline, out_group_from_pipeline) =
+      tmp_tpl;
 
   if (ng_encap_impl_.GetNgraphFreshnessTracker() == nullptr) {
     auto creator = [](NGraphFreshnessTracker** tracker) {

--- a/ngraph_bridge/ngraph_encapsulate_op.h
+++ b/ngraph_bridge/ngraph_encapsulate_op.h
@@ -40,8 +40,8 @@ class NGraphEncapsulateOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override;
 
  private:
-  NGraphEncapsulateImpl ng_encap_impl;
-  std::mutex m_compute_lock;
+  NGraphEncapsulateImpl ng_encap_impl_;
+  std::mutex compute_lock_;
 };
 
 }  // namespace ngraph_bridge


### PR DESCRIPTION
1. Encapsulate's member variables end with `_` to follow TF convention
2. `CachePipelinedTensorIfNeeded` renamed to `UpdatePipelinedTensorCache`
3. Single `ClearExecMaps` function instead of 5 different clear functions to clear the ngexec maps
4. Certain functions of impl are only used in varopts path, so moved them under an `#ifdef NGRAPH_TF_ENABLE_VARIABLES_AND_OPTIMIZERS`
5. `SetCopyLog` incorrectly resets the stringstream. Correcting it to append, and renaming it to `AppendCopyLog`
6. Added `GetPipelineIdxAndTensors` that subsumes 3 function calls. Moved subsumed functions to `private`, since they are no longer being used by encapsulate op directly


TODO: check speeds of resnet etc on CPU/GPU on normal/varopts builds

https://jira.devtools.intel.com/browse/NGTF-2263


Abandoning in favor of: https://github.com/tensorflow/ngraph-bridge/pull/257
