### PR TITLE
sarkars/tf to ng node names

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -29,6 +29,7 @@
 #include "ngraph/op/util/logical_reduction.hpp"
 
 #include "logging/ngraph_log.h"
+#include "ngraph_bridge/ngraph_api.h"
 #include "ngraph_bridge/ngraph_backend_manager.h"
 #include "ngraph_bridge/ngraph_builder.h"
 #include "ngraph_bridge/ngraph_conversions.h"
@@ -97,7 +98,7 @@ std::shared_ptr<TOpType> ConstructNgNode(const std::string& op_name,
   auto ng_node = std::make_shared<TOpType>(std::forward<TArg>(Args)...);
   ng_node->set_friendly_name(op_name);
   ng_node->add_provenance_tag(op_name);
-  if (IsLoggingPlacement()) {
+  if (config::IsLoggingPlacement()) {
     cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
   }
   return ng_node;

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -97,6 +97,9 @@ std::shared_ptr<TOpType> ConstructNgNode(const std::string& op_name,
   auto ng_node = std::make_shared<TOpType>(std::forward<TArg>(Args)...);
   ng_node->set_friendly_name(op_name);
   ng_node->add_provenance_tag(op_name);
+  if (IsLoggingPlacement()) {
+    cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
+  }
   return ng_node;
 }
 


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/NGTF-2256

Sample logs from `NGRAPH_TF_LOG_PLACEMENT=1 pytest test_relu6.py`

TF_to_NG: add_2 --> Add_673
TF_to_NG: add_1_ngraph/_0 --> Add_674
TF_to_NG: add_3 --> Add_675
TF_to_NG: mul_ngraph/_1 --> Multiply_676
TF_to_NG: Relu6_ngraph/_2 --> Constant_677
TF_to_NG: Relu6_ngraph/_2 --> Relu_678
TF_to_NG: Relu6_ngraph/_2 --> Minimum_679

A TF node can have multiple lines, in case it gives rise to multiple ng nodes. Those lines will be contagious though.

For grappler pass, we attach identity nodes, so the original node name is change. For example in this log, `Relu6` is changed to `Relu6_ngraph`