### PR TITLE
Sarkars/debug 2 provenance tags for single node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ if (NOT USE_PRE_BUILT_NGRAPH)
     ExternalProject_Add(
         ext_ngraph
         GIT_REPOSITORY https://github.com/NervanaSystems/ngraph
-        GIT_TAG v0.25.1-rc.7
+        GIT_TAG v0.25.1-rc.8
         CMAKE_ARGS 
             -DNGRAPH_DISTRIBUTED_ENABLE=${NGRAPH_DISTRIBUTED_ENABLE}
             -DNGRAPH_INSTALL_PREFIX=${NGRAPH_ARTIFACTS_DIR}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Once TensorFlow's dependencies are installed, clone the `ngraph-bridge` repo:
 
         git clone https://github.com/tensorflow/ngraph-bridge.git
         cd ngraph-bridge
-        git checkout v0.19.0-rc4
+        git checkout v0.19.0-rc5
 
 Run the following Python script to build TensorFlow, nGraph, and the bridge. Use Python 3.5:
 

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -55,11 +55,11 @@ tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")
 http_archive(
     name = "ngraph",
     build_file = "//:bazel/ngraph.BUILD",
-    sha256 = "345f0566c3ae4a968daea116c26ce9a90a94305148d6b8b56b6309448432492e",
-    strip_prefix = "ngraph-0.25.1-rc.7",
+    sha256 = "4cd939dcf07544dc71f46f422d82a175b210fe7b21417fa67436168d5c40c9dc",
+    strip_prefix = "ngraph-0.25.1-rc.8",
     urls = [
-        "https://mirror.bazel.build/github.com/NervanaSystems/ngraph/archive/v0.25.1-rc.7.tar.gz",
-        "https://github.com/NervanaSystems/ngraph/archive/v0.25.1-rc.7.tar.gz"
+        "https://mirror.bazel.build/github.com/NervanaSystems/ngraph/archive/v0.25.1-rc.8.tar.gz",
+        "https://github.com/NervanaSystems/ngraph/archive/v0.25.1-rc.8.tar.gz"
     ],
 )
 

--- a/bazel/ngraph.BUILD
+++ b/bazel/ngraph.BUILD
@@ -84,7 +84,7 @@ cc_library(
         "-fstack-protector-all",
         '-D SHARED_LIB_PREFIX=\\"lib\\"',
         '-D SHARED_LIB_SUFFIX=\\".so\\"',
-        '-D NGRAPH_VERSION=\\"v0.25.1-rc.7\\"',
+        '-D NGRAPH_VERSION=\\"v0.25.1-rc.8\\"',
         "-D NGRAPH_DEX_ONLY",
         '-D PROJECT_ROOT_DIR=\\"\\"',
         '-D NGRAPH_STATIC_LIB_ENABLE'
@@ -117,7 +117,7 @@ cc_library(
         "-fstack-protector-all",
         '-D SHARED_LIB_PREFIX=\\"lib\\"',
         '-D SHARED_LIB_SUFFIX=\\".so\\"',
-        '-D NGRAPH_VERSION=\\"v0.25.1-rc.7\\"',
+        '-D NGRAPH_VERSION=\\"v0.25.1-rc.8\\"',
         "-D NGRAPH_DEX_ONLY",
         '-D PROJECT_ROOT_DIR=\\"\\"',
     ] + CXX_ABI,

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -53,7 +53,7 @@ def main():
     '''
 
     # Component versions
-    ngraph_version = "v0.25.1-rc.7"
+    ngraph_version = "v0.25.1-rc.8"
     tf_version = "v1.14.0"
 
     # Command line parser options

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -5144,9 +5144,13 @@ Status Builder::TranslateGraph(
     if (!check_if_result_or_parameter(n)) {
       num_tags = n->get_provenance_tags().size();
       if (num_tags != 1) {
+        // In case of an error (num_tags != 1), we dump the ngraph json
+        // However by default the json will not contain the provenance
+        // information. So enable NGRAPH_PROVENANCE_ENABLE, and then reset it
+        // back in the end after NgraphSerialize is done
         char* original_provenance_flag_value =
             getenv("NGRAPH_PROVENANCE_ENABLE");
-        // No need to free original_provenance_flag_value sccording to the
+        // No need to free original_provenance_flag_value according to the
         // standard
 
         char enable_provenance[] = "NGRAPH_PROVENANCE_ENABLE=1";

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -92,15 +92,20 @@ static void SaveNgOp(Builder::OpMap& ng_op_map, const std::string& op_name,
   ng_op_map[op_name].push_back(output_node);
 }
 
-template <class TOpType, class... TArg>
-std::shared_ptr<TOpType> ConstructNgNode(const std::string& op_name,
-                                         TArg&&... Args) {
-  auto ng_node = std::make_shared<TOpType>(std::forward<TArg>(Args)...);
+void SetTracingInfo(const std::string& op_name,
+                    const shared_ptr<ng::Node> ng_node) {
   ng_node->set_friendly_name(op_name);
   ng_node->add_provenance_tag(op_name);
   if (config::IsLoggingPlacement()) {
     cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
   }
+}
+
+template <class TOpType, class... TArg>
+std::shared_ptr<TOpType> ConstructNgNode(const std::string& op_name,
+                                         TArg&&... Args) {
+  auto ng_node = std::make_shared<TOpType>(std::forward<TArg>(Args)...);
+  SetTracingInfo(op_name, ng_node);
   return ng_node;
 }
 
@@ -352,8 +357,12 @@ PerformNgBroadcast(const string& prov_tag, std::shared_ptr<ng::Node> ng_lhs,
   std::shared_ptr<ng::Node> ng_lhs_new, ng_rhs_new;
   std::tie(ng_lhs_new, ng_rhs_new) =
       ng::builder::numpy_broadcast(std::make_pair(ng_lhs, ng_rhs));
-  if (ng_lhs_new != ng_lhs) ng_lhs_new->add_provenance_tag(prov_tag);
-  if (ng_rhs_new != ng_rhs) ng_rhs_new->add_provenance_tag(prov_tag);
+  if (ng_lhs_new != ng_lhs) {
+    SetTracingInfo(prov_tag, ng_lhs_new);
+  }
+  if (ng_rhs_new != ng_rhs) {
+    SetTracingInfo(prov_tag, ng_rhs_new);
+  }
   return make_pair(ng_lhs_new, ng_rhs_new);
 }
 
@@ -387,7 +396,9 @@ static Status TranslateUnaryOp(
   shared_ptr<ng::Node> ng_input;
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_input));
   auto ng_node = create_unary_op(ng_input);
-  if (ng_node != ng_input) ng_node->add_provenance_tag(op->name());
+  if (ng_node != ng_input) {
+    SetTracingInfo(op->name(), ng_node);
+  }
   SaveNgOp(ng_op_map, op->name(), ng_node);
   return Status::OK();
 }
@@ -448,8 +459,9 @@ static Status TranslateBinaryOp(
   std::tie(ng_lhs, ng_rhs) = PerformNgBroadcast(op->name(), ng_lhs, ng_rhs);
 
   auto ng_node = create_binary_op(ng_lhs, ng_rhs);
-  if (ng_node != ng_lhs && ng_node != ng_rhs)
-    ng_node->add_provenance_tag(op->name());
+  if (ng_node != ng_lhs && ng_node != ng_rhs) {
+    SetTracingInfo(op->name(), ng_node);
+  }
 
   SaveNgOp(ng_op_map, op->name(), ng_node);
 
@@ -541,7 +553,7 @@ static Status TranslateQuantizedPoolOp(const Node* op,
         ng_input, ng_kernel_shape, ng_strides, ng_padding_below,
         ng_padding_above, dummy_min, dummy_max);
   }
-  ng_quant_pool->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_quant_pool);
 
   BatchToTensorflow(op->name(), is_nhwc, ng_quant_pool);
   SaveNgOp(ng_op_map, op->name(), ng_quant_pool);
@@ -801,7 +813,7 @@ static Status TranslateBatchMatMulOp(
       ng_lhs_axes.push_back(n_dims - 1);
       ng_lhs_axes.push_back(n_dims - 2);
       ng_lhs = ng::builder::numpy_transpose(ng_lhs, ng_lhs_axes);
-      ng_lhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_lhs);
       ng_lhs_shape = ng_lhs->get_shape();
     } else {
       ng_lhs_axes.push_back(n_dims - 2);
@@ -812,7 +824,7 @@ static Status TranslateBatchMatMulOp(
       ng_rhs_axes.push_back(n_dims - 1);
       ng_rhs_axes.push_back(n_dims - 2);
       ng_rhs = ng::builder::numpy_transpose(ng_rhs, ng_rhs_axes);
-      ng_rhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_rhs);
       ng_rhs_shape = ng_rhs->get_shape();
     } else {
       ng_rhs_axes.push_back(n_dims - 2);
@@ -856,18 +868,18 @@ static Status TranslateBatchMatMulOp(
       ng_lhs_axes.push_back(n_dims - 1);
       ng_lhs_axes.push_back(n_dims - 2);
       ng_lhs = ng::builder::numpy_transpose(ng_lhs, ng_lhs_axes);
-      ng_lhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_lhs);
     }
     if (tf_adj_y) {
       ng_rhs_axes.insert(ng_rhs_axes.begin(), n_dims - 2);
       ng_rhs_axes.insert(ng_rhs_axes.begin(), n_dims - 1);
       ng_rhs = ng::builder::numpy_transpose(ng_rhs, ng_rhs_axes);
-      ng_rhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_rhs);
     } else {
       ng_rhs_axes.insert(ng_rhs_axes.begin(), n_dims - 1);
       ng_rhs_axes.insert(ng_rhs_axes.begin(), n_dims - 2);
       ng_rhs = ng::builder::numpy_transpose(ng_rhs, ng_rhs_axes);
-      ng_rhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_rhs);
     }
 
     ng_lhs_shape = ng_lhs->get_shape();
@@ -1132,7 +1144,7 @@ static Status TranslateCombinedNonMaxSuppressionOp(
                             op->name(),
                             " backend could not return valid ngraph node");
   }
-  ng_cnms->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_cnms);
   shared_ptr<ngraph::Node> ng_nmsed_boxes =
       ConstructNgNode<ngraph::op::GetOutputElement>(op->name(), ng_cnms, 0);
   shared_ptr<ngraph::Node> ng_nmsed_scores =
@@ -1263,7 +1275,7 @@ static Status TranslateConv2DOp(const Node* op,
   ng_kernel_shape[0] = ng_filter_shape[0];
   ng_kernel_shape[1] = ng_filter_shape[1];
   Reshape<3, 2, 0, 1>(ng_filter);
-  ng_filter->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_filter);
 
   NGRAPH_VLOG(3) << "ng_kernel_shape: " << ng::join(ng_kernel_shape);
 
@@ -1399,7 +1411,7 @@ static Status TranslateConv2DBackpropFilterOp(
   // Reshape the output to tf format : [filter_height, filter_width,
   // in_channels, out_channels]
   Reshape<2, 3, 1, 0>(ng_back_prop_filter);
-  ng_back_prop_filter->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_back_prop_filter);
 
   SaveNgOp(ng_op_map, op->name(), ng_back_prop_filter);
   return Status::OK();
@@ -1475,7 +1487,7 @@ static Status TranslateConv2DBackpropInputOp(
   ng_kernel_shape[0] = ng_filter_shape[0];
   ng_kernel_shape[1] = ng_filter_shape[1];
   Reshape<3, 2, 0, 1>(ng_filter);
-  ng_filter->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_filter);
 
   NGRAPH_VLOG(3) << "ng_kernel_shape: " << ng::join(ng_kernel_shape);
 
@@ -1554,7 +1566,7 @@ static Status TranslateConv3DOp(const Node* op,
   ng_kernel_shape[1] = ng_filter_shape[1];
   ng_kernel_shape[2] = ng_filter_shape[2];
   Reshape3D<4, 3, 0, 1, 2>(ng_filter);
-  ng_filter->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_filter);
 
   NGRAPH_VLOG(3) << "ng_kernel_shape: " << ng::join(ng_kernel_shape);
 
@@ -1723,7 +1735,7 @@ static Status TranslateDepthToSpaceOp(const Node* op,
 
   auto transposed =
       ng::builder::numpy_transpose(reshaped, ng_transpose_permutation);
-  transposed->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), transposed);
 
   ng::AxisVector ng_axis_order_second_reshape(transposed->get_shape().size());
   std::iota(ng_axis_order_second_reshape.begin(),
@@ -1780,7 +1792,7 @@ static Status TranslateDepthwiseConv2dNativeOp(
   ng_kernel_shape[0] = ng_filter_shape[0];
   ng_kernel_shape[1] = ng_filter_shape[1];
   Reshape<3, 2, 0, 1>(ng_filter);
-  ng_filter->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_filter);
 
   NGRAPH_VLOG(3) << "ng_kernel_shape: " << ng::join(ng_kernel_shape);
 
@@ -2177,12 +2189,12 @@ static Status TranslateFusedMatMulOp(const Node* op,
     if (GetNodeAttr(op->attrs(), "transpose_a", &transpose_a) == Status::OK() &&
         transpose_a) {
       ng_lhs = ng::builder::numpy_transpose(ng_lhs, ng::AxisVector{1, 0});
-      ng_lhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_lhs);
     }
     if (GetNodeAttr(op->attrs(), "transpose_b", &transpose_b) == Status::OK() &&
         transpose_b) {
       ng_rhs = ng::builder::numpy_transpose(ng_rhs, ng::AxisVector{1, 0});
-      ng_rhs->add_provenance_tag(op->name());
+      SetTracingInfo(op->name(), ng_rhs);
     }
 
     // The default axis count for nGraph's Dot op is 1, which is just what
@@ -2295,7 +2307,7 @@ static Status TranslateGatherV2Op(
     return errors::Internal("In translating GatherV2 op ", op->name(),
                             " backend could not return valid ngraph node");
   }
-  ng_gather->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_gather);
   SaveNgOp(ng_op_map, op->name(), ng_gather);
 
   return Status::OK();
@@ -2360,7 +2372,7 @@ static Status TranslateFusedConv2DOp(const Node* op,
     ng_kernel_shape[0] = ng_filter_shape[0];
     ng_kernel_shape[1] = ng_filter_shape[1];
     Reshape<3, 2, 0, 1>(ng_filter);
-    ng_filter->add_provenance_tag(op->name());
+    SetTracingInfo(op->name(), ng_filter);
 
     NGRAPH_VLOG(3) << "ng_kernel_shape: " << ng::join(ng_kernel_shape);
 
@@ -2575,12 +2587,12 @@ static Status TranslateMatMulOp(const Node* op,
   if (GetNodeAttr(op->attrs(), "transpose_a", &transpose_a) == Status::OK() &&
       transpose_a) {
     ng_lhs = ng::builder::numpy_transpose(ng_lhs, ng::AxisVector{1, 0});
-    ng_lhs->add_provenance_tag(op->name());
+    SetTracingInfo(op->name(), ng_lhs);
   }
   if (GetNodeAttr(op->attrs(), "transpose_b", &transpose_b) == Status::OK() &&
       transpose_b) {
     ng_rhs = ng::builder::numpy_transpose(ng_rhs, ng::AxisVector{1, 0});
-    ng_rhs->add_provenance_tag(op->name());
+    SetTracingInfo(op->name(), ng_rhs);
   }
 
   // The default axis count for nGraph's Dot op is 1, which is just what
@@ -2836,7 +2848,7 @@ static Status TranslateNonMaxSuppressionV4Op(
                             op->name(),
                             " backend could not return valid ngraph node");
   }
-  ng_nmsv4->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_nmsv4);
   shared_ptr<ngraph::Node> ng_selected_indices =
       ConstructNgNode<ngraph::op::GetOutputElement>(op->name(), ng_nmsv4, 0);
   shared_ptr<ngraph::Node> ng_valid_output =
@@ -2877,7 +2889,7 @@ static Status TranslateReduceOp(
 
   std::shared_ptr<ng::Node> ng_node =
       create_ng_node(ng_input, ng_reduction_axes);
-  ng_node->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_node);
 
   // If keep_dims is specified we need to reshape to put back the reduced
   // axes, with length 1.
@@ -2909,7 +2921,7 @@ static Status TranslateMeanOp(
                                       ng::AxisSet ng_reduction_axes) {
                              auto mean_node =
                                  ng::builder::mean(ng_input, ng_reduction_axes);
-                             mean_node->add_provenance_tag(op_name);
+                             SetTracingInfo(op_name, mean_node);
                              return mean_node;
                            });
 }
@@ -3351,7 +3363,7 @@ static Status TranslateQuantizedConcatOpHelper(
 
   auto ng_qconcat = ng::builder::ScaledQuantizedConcat(
       ng_args, size_t(concat_axis), ng_all_mins, ng_all_maxs);
-  ng_qconcat->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_qconcat);
 
   SaveNgOp(ng_op_map, op->name(), ng_qconcat);
   SaveNgOp(ng_op_map, op->name(), ng_min_of_mins);
@@ -3412,7 +3424,7 @@ static Status TranslateQuantizedConv(
   ng_kernel_shape[0] = ng_filter_shape[0];
   ng_kernel_shape[1] = ng_filter_shape[1];
   Reshape<3, 2, 0, 1>(node_inps[1]);
-  node_inps[1]->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), node_inps[1]);
   ng::CoordinateDiff ng_padding_below{0, 0};
   ng::CoordinateDiff ng_padding_above{0, 0};
   Builder::MakePadding(tf_padding_type, ng_image_shape, ng_kernel_shape,
@@ -3426,7 +3438,7 @@ static Status TranslateQuantizedConv(
   std::shared_ptr<ng::Node> ng_quant_conv_bias = create_quantized_conv_node(
       node_inps, ng_strides, ng_dilations, ng_padding_below, ng_padding_above,
       ng_data_dilations);
-  ng_quant_conv_bias->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_quant_conv_bias);
 
   BatchToTensorflow(op->name(), is_nhwc, ng_quant_conv_bias);
   SaveNgOp(ng_op_map, op->name(), ng_quant_conv_bias);
@@ -3454,7 +3466,7 @@ static Status TranslateQuantizedConv2DWithBiasMaybeReluAndRequantizeOp(
         ng_padding_below, ng_padding_above, ng_data_dilations, node_inps[3],
         node_inps[4], node_inps[5], node_inps[6], node_inps[7], node_inps[8],
         IsRelu);
-    ng_node->add_provenance_tag(op_name);
+    SetTracingInfo(op_name, ng_node);
     return ng_node;
   };
   return TranslateQuantizedConv(op, ng_op_map, create_quantized_conv_node);
@@ -3473,7 +3485,7 @@ static Status TranslateQuantizedConv2DWithBiasSumAndReluAndRequantizeOp(
         ng_dilations, ng_padding_below, ng_padding_above, ng_data_dilations,
         node_inps[3], node_inps[4], node_inps[5], node_inps[6], node_inps[7],
         node_inps[8], node_inps[10], node_inps[11], true);
-    ng_node->add_provenance_tag(op_name);
+    SetTracingInfo(op_name, ng_node);
     return ng_node;
   };
   return TranslateQuantizedConv(op, ng_op_map, create_quantized_conv_node);
@@ -3492,7 +3504,7 @@ static Status TranslateQuantizedConv2DWithBiasSignedSumAndReluAndRequantizeOp(
         ng_dilations, ng_padding_below, ng_padding_above, ng_data_dilations,
         node_inps[3], node_inps[4], node_inps[5], node_inps[6], node_inps[7],
         node_inps[8], node_inps[10], node_inps[11], true);
-    ng_node->add_provenance_tag(op_name);
+    SetTracingInfo(op_name, ng_node);
     return ng_node;
   };
   return TranslateQuantizedConv(op, ng_op_map, create_quantized_conv_node);
@@ -3524,7 +3536,7 @@ static Status TranslateQuantizeV2Op(const Node* op,
 
   auto ng_node = ng::builder::ScaledQuantize(ng_input, ng_min, ng_max, ng_et,
                                              ng::AxisSet(), ng_round_mode);
-  ng_node->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_node);
   SaveNgOp(ng_op_map, op->name(), ng_node);
   SaveNgOp(ng_op_map, op->name(), ng_min);
   SaveNgOp(ng_op_map, op->name(), ng_max);
@@ -3541,7 +3553,7 @@ static Status TranslateDequantizeOp(const Node* op,
   // TF only dequantizes to fp32
   auto ng_node = ng::builder::ScaledDequantize(ng_input, ng_min, ng_max,
                                                ng::element::f32, ng::AxisSet());
-  ng_node->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_node);
   SaveNgOp(ng_op_map, op->name(), ng_node);
   return Status::OK();
 }
@@ -4716,7 +4728,7 @@ static Status TranslateTransposeOp(
   NGRAPH_VLOG(3) << ng::join(ng_axis_order);
 
   auto ng_node = ng::builder::numpy_transpose(ng_input, ng_axis_order);
-  ng_node->add_provenance_tag(op->name());
+  SetTracingInfo(op->name(), ng_node);
   SaveNgOp(ng_op_map, op->name(), ng_node);
   return Status::OK();
 }

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -5159,6 +5159,9 @@ Status Builder::TranslateGraph(
     if (!check_if_result_or_parameter(n)) {
       num_tags = n->get_provenance_tags().size();
       if (num_tags != 1) {
+        NgraphSerialize(
+            "tf_function_error_" + ng_function->get_name() + ".json",
+            ng_function);
         return errors::Internal(
             "Found ngraph node ", n->get_name(),
             " which has provenance tag set of size ", num_tags,

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -352,8 +352,8 @@ PerformNgBroadcast(const string& prov_tag, std::shared_ptr<ng::Node> ng_lhs,
   std::shared_ptr<ng::Node> ng_lhs_new, ng_rhs_new;
   std::tie(ng_lhs_new, ng_rhs_new) =
       ng::builder::numpy_broadcast(std::make_pair(ng_lhs, ng_rhs));
-  if (ng_lhs_new != ng_lhs) ng_lhs->add_provenance_tag(prov_tag);
-  if (ng_rhs_new != ng_rhs) ng_rhs->add_provenance_tag(prov_tag);
+  if (ng_lhs_new != ng_lhs) ng_lhs_new->add_provenance_tag(prov_tag);
+  if (ng_rhs_new != ng_rhs) ng_rhs_new->add_provenance_tag(prov_tag);
   return make_pair(ng_lhs_new, ng_rhs_new);
 }
 

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -447,9 +447,6 @@ static Status TranslateBinaryOp(
 
   std::tie(ng_lhs, ng_rhs) = PerformNgBroadcast(op->name(), ng_lhs, ng_rhs);
 
-  std::tie(ng_lhs, ng_rhs) =
-      ng::builder::numpy_broadcast(std::make_pair(ng_lhs, ng_rhs));
-
   auto ng_node = create_binary_op(ng_lhs, ng_rhs);
   ng_node->add_provenance_tag(op->name());
 
@@ -3006,14 +3003,9 @@ static Status TranslateOneHotOp(
 
   // broadcast to make all tensors same shape, as required by ngraph select op
   std::tie(ng_onehot_bool, ng_on) =
-      ng::builder::numpy_broadcast(std::make_pair(ng_onehot_bool, ng_on));
-
-  ng_onehot_bool->add_provenance_tag(op->name());
-  ng_on->add_provenance_tag(op->name());
+      PerformNgBroadcast(op->name(), ng_onehot_bool, ng_on);
   std::tie(ng_onehot_bool, ng_off) =
-      ng::builder::numpy_broadcast(std::make_pair(ng_onehot_bool, ng_off));
-  ng_onehot_bool->add_provenance_tag(op->name());
-  ng_off->add_provenance_tag(op->name());
+      PerformNgBroadcast(op->name(), ng_onehot_bool, ng_off);
 
   auto ng_onehot = ConstructNgNode<ng::op::Select>(op->name(), ng_onehot_bool,
                                                    ng_on, ng_off);
@@ -4863,14 +4855,10 @@ static Status TranslateSelectOp(const Node* op,
         op->name(), ng_input1, ng::AxisVector{0}, tmp_vector);
   }
 
-  std::tie(ng_input1, ng_input2) = ng::builder::numpy_broadcast(
-      std::make_pair(length != 0 ? ng_input_new : ng_input1, ng_input2));
-  ng_input1->add_provenance_tag(op->name());
-  ng_input2->add_provenance_tag(op->name());
+  std::tie(ng_input1, ng_input2) = PerformNgBroadcast(
+      op->name(), (length != 0 ? ng_input_new : ng_input1), ng_input2);
   std::tie(ng_input2, ng_input3) =
-      ng::builder::numpy_broadcast(std::make_pair(ng_input2, ng_input3));
-  ng_input2->add_provenance_tag(op->name());
-  ng_input3->add_provenance_tag(op->name());
+      PerformNgBroadcast(op->name(), ng_input2, ng_input3);
 
   ng_select = ConstructNgNode<ng::op::Select>(op->name(), ng_input1, ng_input2,
                                               ng_input3);

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -387,8 +387,7 @@ static Status TranslateUnaryOp(
   shared_ptr<ng::Node> ng_input;
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_input));
   auto ng_node = create_unary_op(ng_input);
-  if (ng_node != ng_input)
-    ng_node->add_provenance_tag(op->name());
+  if (ng_node != ng_input) ng_node->add_provenance_tag(op->name());
   SaveNgOp(ng_op_map, op->name(), ng_node);
   return Status::OK();
 }
@@ -5125,8 +5124,10 @@ Status Builder::TranslateGraph(
     if (!check_if_result_or_parameter(n)) {
       num_tags = n->get_provenance_tags().size();
       if (num_tags != 1) {
-        char* original_provenance_flag_value = getenv("NGRAPH_PROVENANCE_ENABLE");
-        // No need to free original_provenance_flag_value sccording to the standard
+        char* original_provenance_flag_value =
+            getenv("NGRAPH_PROVENANCE_ENABLE");
+        // No need to free original_provenance_flag_value sccording to the
+        // standard
 
         char enable_provenance[] = "NGRAPH_PROVENANCE_ENABLE=1";
         putenv(enable_provenance);
@@ -5138,7 +5139,9 @@ Status Builder::TranslateGraph(
         } else {
           string provenance_flag_original_val{original_provenance_flag_value};
           char* reset = new char[26 + provenance_flag_original_val.size()];
-          strcpy(reset, ("NGRAPH_PROVENANCE_ENABLE="+provenance_flag_original_val).c_str());
+          strcpy(reset,
+                 ("NGRAPH_PROVENANCE_ENABLE=" + provenance_flag_original_val)
+                     .c_str());
           putenv(reset);
           delete[] reset;
         }

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -94,6 +94,14 @@ static void SaveNgOp(Builder::OpMap& ng_op_map, const std::string& op_name,
 
 void SetTracingInfo(const std::string& op_name,
                     const shared_ptr<ng::Node> ng_node) {
+  // This function is used to trace whng node came from which tf node
+  // It does 3 things:
+  // 1. Attaches provenance tags. This is guaranteed to propagate the tag info
+  // to all nodes.
+  // The next 2 are not guaranteed to be present for all nodes.
+  // But when present they are correct and agree with provenance tags
+  // 2. Attaches friendly names.
+  // 3. Prints a log if NGRAPH_TF_LOG_PLACEMENT=1
   ng_node->set_friendly_name(op_name);
   ng_node->add_provenance_tag(op_name);
   if (config::IsLoggingPlacement()) {

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -5153,12 +5153,17 @@ Status Builder::TranslateGraph(
     return n->is_parameter() || is_result;
   };
 
+  size_t num_tags = 0;
   for (auto n : ng_function->get_ordered_ops()) {
     // Results and Parameters are not expected to have provenance tags
     if (!check_if_result_or_parameter(n)) {
-      if (n->get_provenance_tags().size() == 0) {
-        return errors::Internal("Found ngraph node ", n->get_name(),
-                                " which does not have provenance tag set");
+      num_tags = n->get_provenance_tags().size();
+      if (num_tags != 1) {
+        return errors::Internal(
+            "Found ngraph node ", n->get_name(),
+            " which has provenance tag set of size ", num_tags,
+            ". Expected all ngraph nodes created in TranslateGraph to have "
+            "exactly one provenance tag");
       }
     }
   }

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -1132,6 +1132,7 @@ static Status TranslateCombinedNonMaxSuppressionOp(
                             op->name(),
                             " backend could not return valid ngraph node");
   }
+  ng_cnms->add_provenance_tag(op->name());
   shared_ptr<ngraph::Node> ng_nmsed_boxes =
       ConstructNgNode<ngraph::op::GetOutputElement>(op->name(), ng_cnms, 0);
   shared_ptr<ngraph::Node> ng_nmsed_scores =
@@ -2294,6 +2295,7 @@ static Status TranslateGatherV2Op(
     return errors::Internal("In translating GatherV2 op ", op->name(),
                             " backend could not return valid ngraph node");
   }
+  ng_gather->add_provenance_tag(op->name());
   SaveNgOp(ng_op_map, op->name(), ng_gather);
 
   return Status::OK();
@@ -2834,6 +2836,7 @@ static Status TranslateNonMaxSuppressionV4Op(
                             op->name(),
                             " backend could not return valid ngraph node");
   }
+  ng_nmsv4->add_provenance_tag(op->name());
   shared_ptr<ngraph::Node> ng_selected_indices =
       ConstructNgNode<ngraph::op::GetOutputElement>(op->name(), ng_nmsv4, 0);
   shared_ptr<ngraph::Node> ng_valid_output =

--- a/ngraph_bridge/ngraph_builder.h
+++ b/ngraph_bridge/ngraph_builder.h
@@ -137,6 +137,10 @@ class Builder {
     NGRAPH_VLOG(3) << "ng_padding_above: " << ngraph::join(ng_padding_above);
   }
 
+  static std::pair<std::shared_ptr<ngraph::Node>, std::shared_ptr<ngraph::Node>>
+  PerformNgBroadcast(const string&, std::shared_ptr<ngraph::Node>,
+                     std::shared_ptr<ngraph::Node>);
+
   static const std::map<
       DataType,
       std::pair<std::function<Status(const Node*, ngraph::element::Type,

--- a/ngraph_bridge/ngraph_builder.h
+++ b/ngraph_bridge/ngraph_builder.h
@@ -148,6 +148,17 @@ class Builder {
                 const ngraph::element::Type>>&
   TF_NGRAPH_CONST_MAP();
 
+  // This function is used to trace which ng node came from which tf node
+  // It does 3 things:
+  // 1. Attaches provenance tags. This is guaranteed to propagate the tag info
+  // to all nodes.
+  // The next 2 are not guaranteed to be present for all nodes.
+  // But when present they are correct and agree with provenance tags
+  // 2. Attaches friendly names.
+  // 3. Prints a log if NGRAPH_TF_LOG_PLACEMENT=1
+  static void SetTracingInfo(const std::string& op_name,
+                             const std::shared_ptr<ngraph::Node> ng_node);
+
  private:
   static void ComputeScaleOffsetFolded(const uint& num_bits,
                                        const bool& unsigned_type,

--- a/ngraph_bridge/ngraph_conversions.cc
+++ b/ngraph_bridge/ngraph_conversions.cc
@@ -14,7 +14,8 @@
  * limitations under the License.
  *******************************************************************************/
 
-#include "ngraph_conversions.h"
+#include "ngraph_bridge/ngraph_conversions.h"
+#include "ngraph_bridge/ngraph_api.h"
 
 namespace tensorflow {
 
@@ -31,38 +32,56 @@ void NdhwcToNGraph(std::shared_ptr<ngraph::Node>& ng_node) {
 }
 }  // namespace detail
 
-void BatchToNGraph(const string& provenance_tag, bool is_nhwc,
+void BatchToNGraph(const string& op_name, bool is_nhwc,
                    std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_nhwc) {
     detail::NhwcToNGraph(ng_input);
-    ng_input->add_provenance_tag(provenance_tag);
+    ng_input->set_friendly_name(op_name);
+    ng_input->add_provenance_tag(op_name);
+    if (config::IsLoggingPlacement()) {
+      cout << "TF_to_NG: " << op_name << " --> " << ng_input->get_name()
+           << "\n";
+    }
   }
 }
 
-void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc,
+void BatchToNGraph3D(const string& op_name, bool is_ndhwc,
                      std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_ndhwc) {
     detail::NdhwcToNGraph(ng_input);
-    ng_input->add_provenance_tag(provenance_tag);
+    ng_input->set_friendly_name(op_name);
+    ng_input->add_provenance_tag(op_name);
+    if (config::IsLoggingPlacement()) {
+      cout << "TF_to_NG: " << op_name << " --> " << ng_input->get_name()
+           << "\n";
+    }
   }
 }
 
-void BatchToTensorflow(const string& provenance_tag, bool is_nhwc,
+void BatchToTensorflow(const string& op_name, bool is_nhwc,
                        std::shared_ptr<ngraph::Node>& ng_node) {
   if (!is_nhwc) {
     return;
   }
   Reshape<0, 2, 3, 1>(ng_node);
-  ng_node->add_provenance_tag(provenance_tag);
+  ng_node->set_friendly_name(op_name);
+  ng_node->add_provenance_tag(op_name);
+  if (config::IsLoggingPlacement()) {
+    cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
+  }
 }
 
-void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc,
+void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
                          std::shared_ptr<ngraph::Node>& ng_node) {
   if (!is_ndhwc) {
     return;
   }
   Reshape3D<0, 2, 3, 4, 1>(ng_node);
-  ng_node->add_provenance_tag(provenance_tag);
+  ng_node->set_friendly_name(op_name);
+  ng_node->add_provenance_tag(op_name);
+  if (config::IsLoggingPlacement()) {
+    cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
+  }
 }
 }  // namespace ngraph_bridge
 

--- a/ngraph_bridge/ngraph_conversions.cc
+++ b/ngraph_bridge/ngraph_conversions.cc
@@ -31,21 +31,24 @@ void NdhwcToNGraph(std::shared_ptr<ngraph::Node>& ng_node) {
 }
 }  // namespace detail
 
-void BatchToNGraph(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input) {
+void BatchToNGraph(const string& provenance_tag, bool is_nhwc,
+                   std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_nhwc) {
     detail::NhwcToNGraph(ng_input);
     ng_input->add_provenance_tag(provenance_tag);
   }
 }
 
-void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input) {
+void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc,
+                     std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_ndhwc) {
     detail::NdhwcToNGraph(ng_input);
     ng_input->add_provenance_tag(provenance_tag);
   }
 }
 
-void BatchToTensorflow(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node) {
+void BatchToTensorflow(const string& provenance_tag, bool is_nhwc,
+                       std::shared_ptr<ngraph::Node>& ng_node) {
   if (!is_nhwc) {
     return;
   }

--- a/ngraph_bridge/ngraph_conversions.cc
+++ b/ngraph_bridge/ngraph_conversions.cc
@@ -62,6 +62,7 @@ void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
   if (!is_ndhwc) {
     return;
   }
+  Reshape3D<0, 2, 3, 4, 1>(ng_node);
   Builder::SetTracingInfo(op_name, ng_node);
 }
 }  // namespace ngraph_bridge

--- a/ngraph_bridge/ngraph_conversions.cc
+++ b/ngraph_bridge/ngraph_conversions.cc
@@ -31,31 +31,35 @@ void NdhwcToNGraph(std::shared_ptr<ngraph::Node>& ng_node) {
 }
 }  // namespace detail
 
-void BatchToNGraph(bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input) {
+void BatchToNGraph(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_nhwc) {
     detail::NhwcToNGraph(ng_input);
+    ng_input->add_provenance_tag(provenance_tag);
   }
 }
 
-void BatchToNGraph3D(bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input) {
+void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_ndhwc) {
     detail::NdhwcToNGraph(ng_input);
+    ng_input->add_provenance_tag(provenance_tag);
   }
 }
 
-void BatchToTensorflow(bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node) {
+void BatchToTensorflow(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node) {
   if (!is_nhwc) {
     return;
   }
   Reshape<0, 2, 3, 1>(ng_node);
+  ng_node->add_provenance_tag(provenance_tag);
 }
 
-void BatchToTensorflow3D(bool is_ndhwc,
+void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc,
                          std::shared_ptr<ngraph::Node>& ng_node) {
   if (!is_ndhwc) {
     return;
   }
   Reshape3D<0, 2, 3, 4, 1>(ng_node);
+  ng_node->add_provenance_tag(provenance_tag);
 }
 }  // namespace ngraph_bridge
 

--- a/ngraph_bridge/ngraph_conversions.cc
+++ b/ngraph_bridge/ngraph_conversions.cc
@@ -36,12 +36,7 @@ void BatchToNGraph(const string& op_name, bool is_nhwc,
                    std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_nhwc) {
     detail::NhwcToNGraph(ng_input);
-    ng_input->set_friendly_name(op_name);
-    ng_input->add_provenance_tag(op_name);
-    if (config::IsLoggingPlacement()) {
-      cout << "TF_to_NG: " << op_name << " --> " << ng_input->get_name()
-           << "\n";
-    }
+    Builder::SetTracingInfo(op_name, ng_input);
   }
 }
 
@@ -49,12 +44,7 @@ void BatchToNGraph3D(const string& op_name, bool is_ndhwc,
                      std::shared_ptr<ngraph::Node>& ng_input) {
   if (is_ndhwc) {
     detail::NdhwcToNGraph(ng_input);
-    ng_input->set_friendly_name(op_name);
-    ng_input->add_provenance_tag(op_name);
-    if (config::IsLoggingPlacement()) {
-      cout << "TF_to_NG: " << op_name << " --> " << ng_input->get_name()
-           << "\n";
-    }
+    Builder::SetTracingInfo(op_name, ng_input);
   }
 }
 
@@ -64,11 +54,7 @@ void BatchToTensorflow(const string& op_name, bool is_nhwc,
     return;
   }
   Reshape<0, 2, 3, 1>(ng_node);
-  ng_node->set_friendly_name(op_name);
-  ng_node->add_provenance_tag(op_name);
-  if (config::IsLoggingPlacement()) {
-    cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
-  }
+  Builder::SetTracingInfo(op_name, ng_node);
 }
 
 void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
@@ -76,12 +62,7 @@ void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
   if (!is_ndhwc) {
     return;
   }
-  Reshape3D<0, 2, 3, 4, 1>(ng_node);
-  ng_node->set_friendly_name(op_name);
-  ng_node->add_provenance_tag(op_name);
-  if (config::IsLoggingPlacement()) {
-    cout << "TF_to_NG: " << op_name << " --> " << ng_node->get_name() << "\n";
-  }
+  Builder::SetTracingInfo(op_name, ng_node);
 }
 }  // namespace ngraph_bridge
 

--- a/ngraph_bridge/ngraph_conversions.h
+++ b/ngraph_bridge/ngraph_conversions.h
@@ -103,9 +103,11 @@ void NdhwcToNcdhw(const std::vector<T>& src, std::vector<size_t>& dst) {
 }
 }
 
-void BatchToNGraph(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input);
+void BatchToNGraph(const string& provenance_tag, bool is_nhwc,
+                   std::shared_ptr<ngraph::Node>& ng_input);
 
-void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input);
+void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc,
+                     std::shared_ptr<ngraph::Node>& ng_input);
 
 template <typename T>
 void BatchedOpParamToNGraph(bool is_nhwc, const std::vector<T>& src,
@@ -147,9 +149,11 @@ void BatchedOpParamReshape3D(bool is_ndhwc, const std::vector<T>& src,
   }
 }
 
-void BatchToTensorflow(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node);
+void BatchToTensorflow(const string& provenance_tag, bool is_nhwc,
+                       std::shared_ptr<ngraph::Node>& ng_node);
 
-void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_node);
+void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc,
+                         std::shared_ptr<ngraph::Node>& ng_node);
 
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_conversions.h
+++ b/ngraph_bridge/ngraph_conversions.h
@@ -103,10 +103,10 @@ void NdhwcToNcdhw(const std::vector<T>& src, std::vector<size_t>& dst) {
 }
 }
 
-void BatchToNGraph(const string& provenance_tag, bool is_nhwc,
+void BatchToNGraph(const string& op_name, bool is_nhwc,
                    std::shared_ptr<ngraph::Node>& ng_input);
 
-void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc,
+void BatchToNGraph3D(const string& op_name, bool is_ndhwc,
                      std::shared_ptr<ngraph::Node>& ng_input);
 
 template <typename T>
@@ -149,10 +149,10 @@ void BatchedOpParamReshape3D(bool is_ndhwc, const std::vector<T>& src,
   }
 }
 
-void BatchToTensorflow(const string& provenance_tag, bool is_nhwc,
+void BatchToTensorflow(const string& op_name, bool is_nhwc,
                        std::shared_ptr<ngraph::Node>& ng_node);
 
-void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc,
+void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
                          std::shared_ptr<ngraph::Node>& ng_node);
 
 }  // namespace ngraph_bridge

--- a/ngraph_bridge/ngraph_conversions.h
+++ b/ngraph_bridge/ngraph_conversions.h
@@ -103,9 +103,9 @@ void NdhwcToNcdhw(const std::vector<T>& src, std::vector<size_t>& dst) {
 }
 }
 
-void BatchToNGraph(bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input);
+void BatchToNGraph(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_input);
 
-void BatchToNGraph3D(bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input);
+void BatchToNGraph3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_input);
 
 template <typename T>
 void BatchedOpParamToNGraph(bool is_nhwc, const std::vector<T>& src,
@@ -147,9 +147,9 @@ void BatchedOpParamReshape3D(bool is_ndhwc, const std::vector<T>& src,
   }
 }
 
-void BatchToTensorflow(bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node);
+void BatchToTensorflow(const string& provenance_tag, bool is_nhwc, std::shared_ptr<ngraph::Node>& ng_node);
 
-void BatchToTensorflow3D(bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_node);
+void BatchToTensorflow3D(const string& provenance_tag, bool is_ndhwc, std::shared_ptr<ngraph::Node>& ng_node);
 
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/version.cc
+++ b/ngraph_bridge/version.cc
@@ -32,7 +32,7 @@
 // candidate such as v0.7.0-rc0
 // The code in master will always have the last released version number
 // with a suffix of '-master'
-#define NG_TF_VERSION_SUFFIX "-rc4"
+#define NG_TF_VERSION_SUFFIX "-rc5"
 
 #define VERSION_STR_HELPER(x) #x
 #define VERSION_STR(x) VERSION_STR_HELPER(x)

--- a/python/setup.in.py
+++ b/python/setup.in.py
@@ -59,7 +59,7 @@ package_data_dict['ngraph_bridge'] = include_list
 
 setup( 
     name='ngraph_tensorflow_bridge',
-    version='0.19.0rc4',
+    version='0.19.0rc5',
     description='Intel nGraph compiler and runtime for TensorFlow',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/conversions.cpp
+++ b/test/conversions.cpp
@@ -37,7 +37,7 @@ TEST(conversions, batch_to_tensorflow_nchw) {
   auto shape = ng::Shape{2, 3, 4, 5};
   std::shared_ptr<ng::Node> ng_node =
       make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToTensorflow(false, ng_node);
+  BatchToTensorflow("tag", false, ng_node);
   ASSERT_EQ(ng_node->get_shape(), shape);
 }
 
@@ -45,7 +45,7 @@ TEST(conversions, batch_to_tensorflow_nhwc) {
   auto shape = ng::Shape{2, 3, 4, 5};
   std::shared_ptr<ng::Node> ng_node =
       make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToTensorflow(true, ng_node);
+  BatchToTensorflow("tag", true, ng_node);
   ASSERT_EQ(ng_node->get_shape(), (ng::Shape{2, 4, 5, 3}));
 }
 
@@ -53,7 +53,7 @@ TEST(conversions, batch_to_ngraph_nchw) {
   auto shape = ng::Shape{2, 3, 4, 5};
   std::shared_ptr<ng::Node> ng_node =
       make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToNGraph(false, ng_node);
+  BatchToNGraph("tag", false, ng_node);
   ASSERT_EQ(ng_node->get_shape(), shape);
 }
 
@@ -69,7 +69,7 @@ TEST(conversions, batch_to_ngraph_nhwc) {
   auto shape = ng::Shape{2, 3, 4, 5};
   std::shared_ptr<ng::Node> ng_node =
       make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToNGraph(true, ng_node);
+  BatchToNGraph("tag", true, ng_node);
   ASSERT_EQ(ng_node->get_shape(), (ng::Shape{2, 5, 3, 4}));
 }
 

--- a/test/python/test_provenance_tags_attachment.py
+++ b/test/python/test_provenance_tags_attachment.py
@@ -58,4 +58,7 @@ class TestProductOperations(NgraphTest):
         inp1 = tf.placeholder(tf.float64, shape=[2], name='input1')
         out_node = inp0 / inp1
         self.with_ngraph(lambda sess: sess.run(
-            out_node, feed_dict={inp0: np.ones([2, 2]), inp1: np.ones([2])}))
+            out_node, feed_dict={
+                inp0: np.ones([2, 2]),
+                inp1: np.ones([2])
+            }))

--- a/test/python/test_provenance_tags_attachment.py
+++ b/test/python/test_provenance_tags_attachment.py
@@ -29,7 +29,7 @@ from common import NgraphTest
 
 class TestProductOperations(NgraphTest):
 
-    def test_resnet_like_block(self):
+    def test_provenance_for_no_effect_broadcast(self):
         # Creates a network: y = x + |x|
         #            ---------
         #          /           \
@@ -52,3 +52,10 @@ class TestProductOperations(NgraphTest):
         out_node = tf.add(tf.math.abs(inp, name="abs"), inp, name="add")
         self.with_ngraph(lambda sess: sess.run(
             out_node, feed_dict={inp: np.ones([1, 32, 32, 2])}))
+
+    def test_provenance_for_broadcast_with_effect(self):
+        inp0 = tf.placeholder(tf.float64, shape=[2, 2], name='input0')
+        inp1 = tf.placeholder(tf.float64, shape=[2], name='input1')
+        out_node = inp0 / inp1
+        self.with_ngraph(lambda sess: sess.run(
+            out_node, feed_dict={inp0: np.ones([2, 2]), inp1: np.ones([2])}))

--- a/test/python/test_provenance_tags_attachment.py
+++ b/test/python/test_provenance_tags_attachment.py
@@ -1,0 +1,54 @@
+# ==============================================================================
+#  Copyright 2019 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ==============================================================================
+"""nGraph TensorFlow bridge prod operations test
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest
+import numpy as np
+import tensorflow as tf
+
+from common import NgraphTest
+
+
+class TestProductOperations(NgraphTest):
+
+    def test_resnet_like_block(self):
+        # Creates a network: y = x + |x|
+        #            ---------
+        #          /           \
+        # inp----->             + ---> out_node
+        #          \           /
+        #           ---abs----
+        # The translation of the Add node, first broadcasts the 2 inputs
+        # it receives and then creates an ngraph Add node.
+        # Since the shapes of the inputs to the TF add node are same,
+        # the broadcast builder will return the exact same inputs (lhs and rhs)
+        # without creating new ng nodes
+        # If we do not take care, we could be adding a tag to the ng abs node
+        # when tagging the return of the broadcast builder
+
+        # This test makes sure that TranslateGraph checks that the 
+        # builder returned nodes are different from its inputs,
+        # and only in that case it adds provenance tags
+
+        inp = tf.placeholder(tf.float64, shape=[1, 32, 32, 2], name='input')
+        out_node = tf.add(tf.math.abs(inp, name="abs"), inp, name="add")
+        self.with_ngraph(lambda sess: sess.run(
+            out_node, feed_dict={inp: np.ones([1, 32, 32, 2])}))

--- a/test/python/test_provenance_tags_attachment.py
+++ b/test/python/test_provenance_tags_attachment.py
@@ -44,7 +44,7 @@ class TestProductOperations(NgraphTest):
         # If we do not take care, we could be adding a tag to the ng abs node
         # when tagging the return of the broadcast builder
 
-        # This test makes sure that TranslateGraph checks that the 
+        # This test makes sure that TranslateGraph checks that the
         # builder returned nodes are different from its inputs,
         # and only in that case it adds provenance tags
 

--- a/test/python/test_provenance_tags_attachment.py
+++ b/test/python/test_provenance_tags_attachment.py
@@ -54,11 +54,16 @@ class TestProductOperations(NgraphTest):
             out_node, feed_dict={inp: np.ones([1, 32, 32, 2])}))
 
     def test_provenance_for_broadcast_with_effect(self):
+        # In this test, the broadcast actually produces new ng nodes
+        # as opposed to test_provenance_for_no_effect_broadcast,
+        # which is a dummy broadcast
+        # so test that they are tagged appropriately
         inp0 = tf.placeholder(tf.float64, shape=[2, 2], name='input0')
         inp1 = tf.placeholder(tf.float64, shape=[2], name='input1')
-        out_node = inp0 / inp1
-        self.with_ngraph(lambda sess: sess.run(
-            out_node, feed_dict={
-                inp0: np.ones([2, 2]),
-                inp1: np.ones([2])
-            }))
+        out_node0 = inp0 / inp1
+        out_node1 = inp1 / inp0
+        self.with_ngraph(lambda sess: sess.run([out_node0, out_node1],
+                                               feed_dict={
+                                                   inp0: np.ones([2, 2]),
+                                                   inp1: np.ones([2])
+                                               }))


### PR DESCRIPTION
1.
Add check so that each ng node (other than parameter an dresult) have exactly 1 provenance tag

2.
Make `ngraph_conversion.cpp` functions (like `BatchToNGraph`) accept a prov tag and only tag if a new node is created

3.
Adds `PerformNgBroadcast` to call `ng::builder::numpy_broadcast` and add provenance tags appropriately. All other builders used will return a new ng node, so this special care does not need to be taken

4.
Without these changes, certain graphs (as shown in the pytest) will have nodes that have 2 provenance tags
Tests: 1 pytest that has a broadcast that does not create new ng nodes, and another with a broadcast that does create new ng nodes

5.
Also updates r0.19's version and ngcore version

6.
Also add full path to header in ngraph_conversions.cc
#include "ngraph_conversions.h" -->
#include "ngraph_bridge/ngraph_conversions.h"

7.
Add `SetTracingInfo` to do provenance tagging, friendly name setting and printing