### PR TITLE
gopoka/[BERT] Implementation of GatherV2 for BERT model.

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2237,35 +2237,76 @@ static Status TranslateGatherV2Op(
   // the full backend creation string
   auto config_map = BackendManager::GetBackendAttributeValues(backend_name);
   if (config_map.at("ngraph_backend") != "NNPI") {
-    return errors::Internal("In translating GatherV2 op ", op->name(),
-                            " found requested backend ", backend_name,
-                            " which is unsupported");
-  }
+    // This workaround works only if axis == 0
+    if (tf_axis[0] != 0) {
+      return errors::Internal("In translating GatherV2 op ", op->name(),
+                              " found requested backend ", backend_name,
+                              " which is unsupported when (axis != 0)");
+    }
 
-  ng::runtime::Backend* backend = BackendManager::GetBackend(backend_name);
+    shared_ptr<ng::Node> ng_params = ng_input;
+    shared_ptr<ng::Node> ng_indices = ng_input_coords;
 
-  // Negative axis is supported. Accounting for that
-  auto ng_input_shape = ng_input->get_shape();
-  size_t ng_input_rank = ng_input_shape.size();
-  int axis;
-  if (tf_axis[0] >= 0) {
-    axis = tf_axis[0];
+    ng::AxisVector ng_axis_order(ng_input_coords->get_shape().size());
+    std::iota(ng_axis_order.begin(), ng_axis_order.end(), 0);
+
+    ng::Shape extended_shape = ng_input_coords->get_shape();
+    extended_shape.push_back(1);
+
+    ng_indices = ConstructNgNode<ng::op::Reshape>(
+        op->name(), ng_indices, ng_axis_order, extended_shape);
+
+    auto ng_params_shape = ng_params->get_shape();
+    size_t ng_params_rank = ng_params_shape.size();
+    size_t ng_indices_rank = ng_indices->get_shape().size();
+
+    for (size_t i = 0; i < ng_params_rank; i++) {
+      if (ng_params_shape[i] == 0) {
+        return errors::InvalidArgument(
+            "Requested more than 0 entries, but params is empty.  Params "
+            "shape: "
+            "[",
+            ng::join(ng_params_shape, ","), "]");
+      }
+    }
+
+    if ((ng_indices_rank - 1) > ng_params_rank) {
+      return errors::InvalidArgument(
+          "The last dimension of indices can be at most the rank of params");
+    }
+
+    SaveNgOp(ng_op_map, op->name(), ConstructNgNode<ng::op::GatherND>(
+                                        op->name(), ng_params, ng_indices));
+
+    // return errors::Internal("In translating GatherV2 op ", op->name(),
+    //                         " found requested backend ", backend_name,
+    //                         " which is unsupported");
   } else {
-    axis = tf_axis[0] + ng_input_rank;
-  }
-  if (axis < 0 || axis >= ng_input_rank) {
-    return errors::InvalidArgument("Expected axis in the range [-",
-                                   ng_input_rank, ", ", ng_input_rank,
-                                   "), but got ", tf_axis[0]);
-  }
+    ng::runtime::Backend* backend = BackendManager::GetBackend(backend_name);
 
-  shared_ptr<ng::Node> ng_gather =
-      backend->get_backend_op("Gather", &ng_input, &ng_input_coords, &axis);
-  if (ng_gather == nullptr) {
-    return errors::Internal("In translating GatherV2 op ", op->name(),
-                            " backend could not return valid ngraph node");
+    // Negative axis is supported. Accounting for that
+    auto ng_input_shape = ng_input->get_shape();
+    size_t ng_input_rank = ng_input_shape.size();
+    int axis;
+    if (tf_axis[0] >= 0) {
+      axis = tf_axis[0];
+    } else {
+      axis = tf_axis[0] + ng_input_rank;
+    }
+    if (axis < 0 || axis >= ng_input_rank) {
+      return errors::InvalidArgument("Expected axis in the range [-",
+                                     ng_input_rank, ", ", ng_input_rank,
+                                     "), but got ", tf_axis[0]);
+    }
+
+    shared_ptr<ng::Node> ng_gather =
+        backend->get_backend_op("Gather", &ng_input, &ng_input_coords, &axis);
+    if (ng_gather == nullptr) {
+      return errors::Internal("In translating GatherV2 op ", op->name(),
+                              " backend could not return valid ngraph node");
+    }
+    SaveNgOp(ng_op_map, op->name(), ng_gather);
   }
-  SaveNgOp(ng_op_map, op->name(), ng_gather);
 
   return Status::OK();
 }

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -661,9 +661,9 @@ Status MarkForClustering(Graph* graph, const std::set<string> skip_these_nodes,
                                                              bool* result) {
     // TODO: replace current_backend ->
     // BackendManager::GetCurrentlySetBackendName()
-    auto config_map =
-        BackendManager::GetBackendAttributeValues(current_backend);
-    *result = (config_map.at("ngraph_backend") == "NNPI");
+    // FIXME(gopoka): GatherV2 is supported only when axis == 0.
+    //                If possible, check should be added here.
+    *result = true;
     return Status::OK();
   };
 

--- a/test/test_array_ops.cpp
+++ b/test/test_array_ops.cpp
@@ -368,7 +368,7 @@ TEST(ArrayOps, GatherNd3D) {
 // Test fails because of this error:
 // Not found: No attr named '_ngraph_backend' in NodeDef:
 // This is because op_executor does not go through mark_for_clustering
-TEST(ArrayOps, DISABLED_GatherV2Vector) {
+TEST(ArrayOps, GatherV2Vector) {
   int dim = 5;
 
   Tensor A(DT_FLOAT, TensorShape({dim}));
@@ -376,6 +376,30 @@ TEST(ArrayOps, DISABLED_GatherV2Vector) {
 
   Tensor B(DT_INT32, TensorShape({2}));
   AssignInputValues<int>(B, {2, 1});
+
+  Tensor C(DT_INT32, TensorShape({}));
+  AssignInputValues<int>(C, 0);
+
+  vector<int> static_input_indexes = {1, 2};
+  vector<DataType> output_datatypes = {DT_FLOAT};
+
+  Scope root = Scope::NewRootScope();
+  auto R = ops::GatherV2(root, A, B, C);
+  std::vector<Output> sess_run_fetchoutputs = {R};
+
+  OpExecuter opexecuter(root, "GatherV2", static_input_indexes,
+                        output_datatypes, sess_run_fetchoutputs);
+
+  opexecuter.RunTest();
+
+}  // end of test op GatherV2
+
+TEST(ArrayOps, GatherV2Tensor) {
+  Tensor A(DT_FLOAT, TensorShape({5, 5, 5, 5}));
+  AssignInputValuesRandom(A);
+
+  Tensor B(DT_INT32, TensorShape({10}));
+  AssignInputValues<int>(B, {0, 4, 2, 2, 3, 1, 3, 0, 3, 3});
 
   Tensor C(DT_INT32, TensorShape({}));
   AssignInputValues<int>(C, 0);


### PR DESCRIPTION
This implementation allows usage of GatherV2 on other backends than NNPI, with the constraint that axis == 0.