### PR TITLE
Remove tbb linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,10 +326,6 @@ if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
         ${LIB_MKLML_INTEL_IMPORTED_LOCATION}
     )
 
-    add_library(lib_tbb INTERFACE)
-    target_link_libraries(lib_tbb INTERFACE
-        ${NGRAPH_INSTALL_DIR}/${LIB}/libtbb.so)
-
     add_library(lib_iomp5 SHARED IMPORTED)
     set_target_properties(
         lib_iomp5

--- a/ngraph_bridge/CMakeLists.txt
+++ b/ngraph_bridge/CMakeLists.txt
@@ -113,7 +113,6 @@ if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
             absl_algorithm
             absl_container
             absl_strings
-            lib_tbb
             lib_mkldnn
             lib_iomp5
         )
@@ -156,7 +155,6 @@ if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
         absl_algorithm
         absl_container
         absl_strings
-        lib_tbb
         lib_mkldnn
         lib_mklml_intel
         lib_iomp5


### PR DESCRIPTION
Removed tbb linking with ngraph_bridge libraries since we build ngraph with `DNGRAPH_TBB_ENABLE=FALSE`