### PR TITLE
Shrestha/detect multiple variable updates merge to master

### DIFF
--- a/ngraph_bridge/enable_variable_ops/ngraph_catalog.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_catalog.cc
@@ -35,29 +35,52 @@ unordered_map<string, tuple<string, bool, bool>>
     NGraphCatalog::encap_output_info_map_;
 
 // Function to create the Node Key
-string NGraphCatalog::CreateNodeKey(int graph_id, string node_name, int index) {
+string NGraphCatalog::CreateNodeKey(const int& graph_id,
+                                    const string& node_name, const int& index) {
   if (index == 0) {
     return to_string(graph_id) + "_" + node_name;
   }
   return to_string(graph_id) + "_" + node_name + ":" + to_string(index);
 }
 
+void NGraphCatalog::ClearCatalog() {
+  NGraphCatalog::ClearInputVariableSharedNameMap();
+  NGraphCatalog::ClearEncapOutputCopyIndexesMap();
+  NGraphCatalog::ClearEncapOutputInfoMap();
+}
+
 // Functions for Encapsulate Output Copy Indexes Map
-void NGraphCatalog::AddToEncapOutputCopyIndexesMap(int graphid,
-                                                   string node_name,
-                                                   unordered_set<int> val) {
+void NGraphCatalog::AddToEncapOutputCopyIndexesMap(
+    const int& graphid, const string& node_name,
+    const unordered_set<int>& val) {
+  if (NGraphCatalog::EncapOutputNeedsCopy(graphid, node_name)) {
+    throw runtime_error(
+        "Trying to add an already existing key in EncapOutputIndexesCopy Map");
+  }
   string key = graphid + "_" + node_name;
-  NGraphCatalog::encap_output_copy_indexes_map_[key] = val;
+  NGraphCatalog::encap_output_copy_indexes_map_.insert({key, val});
 }
 
-unordered_set<int> NGraphCatalog::GetEncapOutputIndexesThatNeedCopy(
-    int graphid, string node_name) {
-  string key = graphid + "_" + node_name;
-  return NGraphCatalog::encap_output_copy_indexes_map_[key];
+void NGraphCatalog::ClearEncapOutputCopyIndexesMap() {
+  NGraphCatalog::encap_output_copy_indexes_map_.clear();
 }
 
-bool NGraphCatalog::EncapOutputIndexNeedsCopy(int graphid, string node_name,
-                                              int index) {
+const unordered_set<int>& NGraphCatalog::GetEncapOutputIndexesThatNeedCopy(
+    const int& graphid, const string& node_name) {
+  string key = graphid + "_" + node_name;
+  return NGraphCatalog::encap_output_copy_indexes_map_.at(key);
+}
+
+bool NGraphCatalog::EncapOutputNeedsCopy(const int& graphid,
+                                         const string& node_name) {
+  string key = graphid + "_" + node_name;
+  auto itr = NGraphCatalog::encap_output_copy_indexes_map_.find(key);
+  return itr != NGraphCatalog::encap_output_copy_indexes_map_.end();
+}
+
+bool NGraphCatalog::EncapOutputIndexNeedsCopy(const int& graphid,
+                                              const string& node_name,
+                                              const int& index) {
   string key = graphid + "_" + node_name;
   auto itr = NGraphCatalog::encap_output_copy_indexes_map_.find(key);
   if (itr != NGraphCatalog::encap_output_copy_indexes_map_.end()) {
@@ -68,89 +91,114 @@ bool NGraphCatalog::EncapOutputIndexNeedsCopy(int graphid, string node_name,
   return true;
 }
 
-void NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(int graphid,
-                                                        string node_name) {
+void NGraphCatalog::DeleteFromEncapOutputCopyIndexesMap(
+    const int& graphid, const string& node_name) {
   string key = graphid + "_" + node_name;
   NGraphCatalog::encap_output_copy_indexes_map_.erase(key);
 }
 
 // Functions relating Input Variable Shared Name Map
-string NGraphCatalog::GetInputVariableSharedName(int graphid, string node_name,
-                                                 int input_index) {
-  std::string node_key =
+void NGraphCatalog::AddToInputVariableSharedNameMap(const string& key,
+                                                    const string& val) {
+  if (NGraphCatalog::ExistsInInputVariableSharedNameMap(key)) {
+    throw runtime_error(
+        "Trying to add an already existing key in InputVariableSharedName Map");
+  }
+  NGraphCatalog::input_variable_sharedname_map_.insert({key, val});
+}
+
+void NGraphCatalog::ClearInputVariableSharedNameMap() {
+  NGraphCatalog::input_variable_sharedname_map_.clear();
+}
+
+const string& NGraphCatalog::GetInputVariableSharedName(
+    const int& graphid, const string& node_name, const int& input_index) {
+  string node_key =
       NGraphCatalog::CreateNodeKey(graphid, node_name, input_index);
-  return NGraphCatalog::input_variable_sharedname_map_[node_key];
+  return NGraphCatalog::input_variable_sharedname_map_.at(node_key);
 }
 
-void NGraphCatalog::AddToInputVariableSharedNameMap(string key, string val) {
-  NGraphCatalog::input_variable_sharedname_map_[key] = val;
-}
-
-bool NGraphCatalog::ExistsInInputVariableSharedNameMap(string key) {
+bool NGraphCatalog::ExistsInInputVariableSharedNameMap(const string& key) {
   auto itr = NGraphCatalog::input_variable_sharedname_map_.find(key);
   return itr != NGraphCatalog::input_variable_sharedname_map_.end();
 }
 
-bool NGraphCatalog::ExistsInInputVariableSharedNameMap(int graphid,
-                                                       string node_name,
-                                                       int input_index) {
+bool NGraphCatalog::ExistsInInputVariableSharedNameMap(const int& graphid,
+                                                       const string& node_name,
+                                                       const int& input_index) {
   return NGraphCatalog::ExistsInInputVariableSharedNameMap(
       NGraphCatalog::CreateNodeKey(graphid, node_name, input_index));
 }
 
-void NGraphCatalog::DeleteFromInputVariableSharedNameMap(string key) {
+void NGraphCatalog::DeleteFromInputVariableSharedNameMap(const string& key) {
   NGraphCatalog::input_variable_sharedname_map_.erase(key);
 }
 
 // Functions for EncapOutputInfo Map
-void NGraphCatalog::AddToEncapOutputInfoMap(string key,
-                                            tuple<string, bool, bool> val) {
-  NGraphCatalog::encap_output_info_map_[key] = val;
+void NGraphCatalog::AddToEncapOutputInfoMap(
+    const string& key, const tuple<string, bool, bool>& val) {
+  if (NGraphCatalog::ExistsInEncapOutputInfoMap(key)) {
+    throw runtime_error(
+        "Trying to add an already existing key in EncapOutputInfo Map");
+  }
+  NGraphCatalog::encap_output_info_map_.insert({key, val});
 }
 
-void NGraphCatalog::AddToEncapOutputInfoMap(string key, string shared_name,
-                                            bool copy_to_tf,
-                                            bool is_tf_just_looking) {
+void NGraphCatalog::AddToEncapOutputInfoMap(const string& key,
+                                            const string& shared_name,
+                                            const bool& copy_to_tf,
+                                            const bool& is_tf_just_looking) {
+  if (NGraphCatalog::ExistsInEncapOutputInfoMap(key)) {
+    throw runtime_error(
+        "Trying to add an already existing key in EncapOutputInfo Map");
+  }
+
   // create a tuple
   tuple<string, bool, bool> val =
       make_tuple(shared_name, copy_to_tf, is_tf_just_looking);
-  NGraphCatalog::encap_output_info_map_[key] = val;
+  NGraphCatalog::encap_output_info_map_.insert({key, val});
 }
 
-bool NGraphCatalog::ExistsInEncapOutputInfoMap(string key) {
+bool NGraphCatalog::ExistsInEncapOutputInfoMap(const string& key) {
   auto itr = NGraphCatalog::encap_output_info_map_.find(key);
   return itr != NGraphCatalog::encap_output_info_map_.end();
 }
 
-bool NGraphCatalog::ExistsInEncapOutputInfoMap(int graphid, string node_name,
-                                               int input_index) {
-  std::string key =
-      NGraphCatalog::CreateNodeKey(graphid, node_name, input_index);
+bool NGraphCatalog::ExistsInEncapOutputInfoMap(const int& graphid,
+                                               const string& node_name,
+                                               const int& input_index) {
+  string key = NGraphCatalog::CreateNodeKey(graphid, node_name, input_index);
   auto itr = NGraphCatalog::encap_output_info_map_.find(key);
   return itr != NGraphCatalog::encap_output_info_map_.end();
 }
 
-tuple<string, bool, bool> NGraphCatalog::GetInfoFromEncapOutputInfoMap(
-    string key) {
-  return NGraphCatalog::encap_output_info_map_[key];
+const tuple<string, bool, bool>& NGraphCatalog::GetInfoFromEncapOutputInfoMap(
+    const string& key) {
+  return NGraphCatalog::encap_output_info_map_.at(key);
 }
 
-string NGraphCatalog::GetVariableSharedNameFromEncapOutputInfoMap(string key) {
-  tuple<string, bool, bool> val = NGraphCatalog::encap_output_info_map_[key];
+const string& NGraphCatalog::GetVariableSharedNameFromEncapOutputInfoMap(
+    const string& key) {
+  tuple<string, bool, bool>& val =
+      NGraphCatalog::encap_output_info_map_.at(key);
   return get<0>(val);
 }
 
-bool NGraphCatalog::GetCopyToTFFromEncapOutputInfoMap(string key) {
-  tuple<string, bool, bool> val = NGraphCatalog::encap_output_info_map_[key];
+const bool& NGraphCatalog::GetCopyToTFFromEncapOutputInfoMap(
+    const string& key) {
+  tuple<string, bool, bool>& val =
+      NGraphCatalog::encap_output_info_map_.at(key);
   return get<1>(val);
 }
 
-bool NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(string key) {
-  tuple<string, bool, bool> val = NGraphCatalog::encap_output_info_map_[key];
+const bool& NGraphCatalog::GetIsTFJustLookingFromEncapOutputInfoMap(
+    const string& key) {
+  tuple<string, bool, bool>& val =
+      NGraphCatalog::encap_output_info_map_.at(key);
   return get<2>(val);
 }
 
-void NGraphCatalog::DeleteFromEncapOutputInfoMap(string key) {
+void NGraphCatalog::DeleteFromEncapOutputInfoMap(const string& key) {
   NGraphCatalog::encap_output_info_map_.erase(key);
 }
 

--- a/ngraph_bridge/enable_variable_ops/ngraph_catalog.h
+++ b/ngraph_bridge/enable_variable_ops/ngraph_catalog.h
@@ -79,43 +79,62 @@ class NGraphCatalog {
 
  public:
   // Utility to create key to query the maps
-  static string CreateNodeKey(int graph_id, string node_name, int index);
+  static string CreateNodeKey(const int& graph_id, const string& node_name,
+                              const int& index);
+  // Clear all the maps
+  static void ClearCatalog();
 
   // Utility Functions for the data structures
   // Functions for EncapsulateOutputCopyIndexes Map
-  static void AddToEncapOutputCopyIndexesMap(int graphid, string node_name,
-                                             unordered_set<int> val);
-  static bool EncapOutputIndexNeedsCopy(int graphid, string node_name,
-                                        int index);
-  static unordered_set<int> GetEncapOutputIndexesThatNeedCopy(int graphid,
-                                                              string node_name);
-  static void DeleteFromEncapOutputCopyIndexesMap(int graphid,
-                                                  string node_name);
+  static void AddToEncapOutputCopyIndexesMap(const int& graphid,
+                                             const string& node_name,
+                                             const unordered_set<int>& val);
+
+  static void ClearEncapOutputCopyIndexesMap();
+
+  static bool EncapOutputNeedsCopy(const int& graphid, const string& node_name);
+
+  static bool EncapOutputIndexNeedsCopy(const int& graphid,
+                                        const string& node_name,
+                                        const int& index);
+  static const unordered_set<int>& GetEncapOutputIndexesThatNeedCopy(
+      const int& graphid, const string& node_name);
+  static void DeleteFromEncapOutputCopyIndexesMap(const int& graphid,
+                                                  const string& node_name);
 
   // Functions for InputVariableSharedName Map
-  static string GetInputVariableSharedName(int graphid, string node_name,
-                                           int input_index);
+  static void AddToInputVariableSharedNameMap(const string& key,
+                                              const string& val);
 
-  static void AddToInputVariableSharedNameMap(string key, string val);
-
-  static bool ExistsInInputVariableSharedNameMap(string key);
-  static bool ExistsInInputVariableSharedNameMap(int graphid, string node_name,
-                                                 int input_index);
-  static void DeleteFromInputVariableSharedNameMap(string key);
+  static void ClearInputVariableSharedNameMap();
+  static const string& GetInputVariableSharedName(const int& graphid,
+                                                  const string& node_name,
+                                                  const int& input_index);
+  static bool ExistsInInputVariableSharedNameMap(const string& key);
+  static bool ExistsInInputVariableSharedNameMap(const int& graphid,
+                                                 const string& node_name,
+                                                 const int& input_index);
+  static void DeleteFromInputVariableSharedNameMap(const string& key);
 
   // Functions for EncapOutputInfo Map
-  static void AddToEncapOutputInfoMap(string key,
-                                      tuple<string, bool, bool> val);
-  static void AddToEncapOutputInfoMap(string key, string shared_name,
-                                      bool copy_to_tf, bool is_tf_just_looking);
-  static bool ExistsInEncapOutputInfoMap(string key);
-  static bool ExistsInEncapOutputInfoMap(int graphid, string node_name,
-                                         int input_index);
-  static tuple<string, bool, bool> GetInfoFromEncapOutputInfoMap(string key);
-  static string GetVariableSharedNameFromEncapOutputInfoMap(string key);
-  static bool GetCopyToTFFromEncapOutputInfoMap(string key);
-  static bool GetIsTFJustLookingFromEncapOutputInfoMap(string key);
-  static void DeleteFromEncapOutputInfoMap(string key);
+  static void AddToEncapOutputInfoMap(const string& key,
+                                      const tuple<string, bool, bool>& val);
+  static void AddToEncapOutputInfoMap(const string& key,
+                                      const string& shared_name,
+                                      const bool& copy_to_tf,
+                                      const bool& is_tf_just_looking);
+  static bool ExistsInEncapOutputInfoMap(const string& key);
+  static bool ExistsInEncapOutputInfoMap(const int& graphid,
+                                         const string& node_name,
+                                         const int& input_index);
+  static const tuple<string, bool, bool>& GetInfoFromEncapOutputInfoMap(
+      const string& key);
+  static const string& GetVariableSharedNameFromEncapOutputInfoMap(
+      const string& key);
+  static const bool& GetCopyToTFFromEncapOutputInfoMap(const string& key);
+  static const bool& GetIsTFJustLookingFromEncapOutputInfoMap(
+      const string& key);
+  static void DeleteFromEncapOutputInfoMap(const string& key);
   static void ClearEncapOutputInfoMap();
   static void PrintEncapOutputInfoMap();
 };

--- a/test/graph_rewrites/capture_variables.cc
+++ b/test/graph_rewrites/capture_variables.cc
@@ -62,14 +62,15 @@ TEST(CaptureVariables, TempVar) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX"){
-      ASSERT_EQ("NGraphVariable", node->type_string());}
-    else if (node_name == "VarY"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "AssignX"){
-      ASSERT_EQ("NGraphAssign", node->type_string());}
-    else if (node_name == "AssignY"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "VarX") {
+      ASSERT_EQ("NGraphVariable", node->type_string());
+    } else if (node_name == "VarY") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "AssignX") {
+      ASSERT_EQ("NGraphAssign", node->type_string());
+    } else if (node_name == "AssignY") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 
@@ -105,12 +106,13 @@ TEST(CaptureVariables, TempVar2) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX"){
-      ASSERT_EQ("NGraphVariable", node->type_string());}
-    else if (node_name == "VarY"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "AssignY"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "VarX") {
+      ASSERT_EQ("NGraphVariable", node->type_string());
+    } else if (node_name == "VarY") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "AssignY") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 
@@ -140,14 +142,15 @@ TEST(CaptureVariables, VariableScope) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX"){
-      ASSERT_EQ("NGraphVariable", node->type_string());}
-    else if (node_name == "VarY"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "AssignX"){
-      ASSERT_EQ("NGraphAssign", node->type_string());}
-    else if (node_name == "AssignY"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "VarX") {
+      ASSERT_EQ("NGraphVariable", node->type_string());
+    } else if (node_name == "VarY") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "AssignX") {
+      ASSERT_EQ("NGraphAssign", node->type_string());
+    } else if (node_name == "AssignY") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 
@@ -183,12 +186,13 @@ TEST(CaptureVariables, SingleVariable1) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "Assign1"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
-    else if (node_name == "Assign2"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "Var") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "Assign1") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    } else if (node_name == "Assign2") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 
@@ -224,12 +228,13 @@ TEST(CaptureVariables, SingleVariable2) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "Assign1"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
-    else if (node_name == "Assign2"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "Var") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "Assign1") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    } else if (node_name == "Assign2") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 
@@ -267,14 +272,15 @@ TEST(CaptureVariables, SingleVariable3) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var"){
-      ASSERT_NE("NGraphVariable", node->type_string());}
-    else if (node_name == "Assign1"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
-    else if (node_name == "Assign2"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
-    else if (node_name == "Assign3"){
-      ASSERT_NE("NGraphAssign", node->type_string());}
+    if (node_name == "Var") {
+      ASSERT_NE("NGraphVariable", node->type_string());
+    } else if (node_name == "Assign1") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    } else if (node_name == "Assign2") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    } else if (node_name == "Assign3") {
+      ASSERT_NE("NGraphAssign", node->type_string());
+    }
   }
 }
 

--- a/test/graph_rewrites/capture_variables.cc
+++ b/test/graph_rewrites/capture_variables.cc
@@ -62,14 +62,14 @@ TEST(CaptureVariables, TempVar) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX")
-      ASSERT_EQ("NGraphVariable", node->type_string());
-    else if (node_name == "VarY")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "AssignX")
-      ASSERT_EQ("NGraphAssign", node->type_string());
-    else if (node_name == "AssignY")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "VarX"){
+      ASSERT_EQ("NGraphVariable", node->type_string());}
+    else if (node_name == "VarY"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "AssignX"){
+      ASSERT_EQ("NGraphAssign", node->type_string());}
+    else if (node_name == "AssignY"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 
@@ -105,12 +105,12 @@ TEST(CaptureVariables, TempVar2) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX")
-      ASSERT_EQ("NGraphVariable", node->type_string());
-    else if (node_name == "VarY")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "AssignY")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "VarX"){
+      ASSERT_EQ("NGraphVariable", node->type_string());}
+    else if (node_name == "VarY"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "AssignY"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 
@@ -140,14 +140,14 @@ TEST(CaptureVariables, VariableScope) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "VarX")
-      ASSERT_EQ("NGraphVariable", node->type_string());
-    else if (node_name == "VarY")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "AssignX")
-      ASSERT_EQ("NGraphAssign", node->type_string());
-    else if (node_name == "AssignY")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "VarX"){
+      ASSERT_EQ("NGraphVariable", node->type_string());}
+    else if (node_name == "VarY"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "AssignX"){
+      ASSERT_EQ("NGraphAssign", node->type_string());}
+    else if (node_name == "AssignY"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 
@@ -155,9 +155,9 @@ TEST(CaptureVariables, VariableScope) {
 // validate_shape = false and also the Variable is shared with
 // another Assign so none of them is captured
 //                           Var
-//                           / \
-//                          /   \
-//                         /     \
+//                           / \ 
+//                          /   \ 
+//                         /     \ 
 //                     Assign1  Assign2
 // validate_shape:     (False)  (True)
 // Var, Assign1, Assign2 should not be captured
@@ -183,12 +183,12 @@ TEST(CaptureVariables, SingleVariable1) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "Assign1")
-      ASSERT_NE("NGraphAssign", node->type_string());
-    else if (node_name == "Assign2")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "Var"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "Assign1"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
+    else if (node_name == "Assign2"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 
@@ -196,9 +196,9 @@ TEST(CaptureVariables, SingleVariable1) {
 // validate_shape = false and also the Variable is shared with
 // another Assign so none of them is captured
 //                           Var
-//                           / \
-//                          /   \
-//                         /     \
+//                           / \ 
+//                          /   \ 
+//                         /     \ 
 //                     Assign1  Assign2
 // validate_shape:     (True)   (False)
 // Var, Assign1, Assign2 should not be captured
@@ -224,19 +224,19 @@ TEST(CaptureVariables, SingleVariable2) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "Assign1")
-      ASSERT_NE("NGraphAssign", node->type_string());
-    else if (node_name == "Assign2")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "Var"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "Assign1"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
+    else if (node_name == "Assign2"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 
 //                           Var
-//                           / \
-//                          /   \
-//                         /     \
+//                           / \ 
+//                          /   \ 
+//                         /     \ 
 //               (True)Assign1  Assign3(True)
 //                        |
 //                        |
@@ -267,14 +267,14 @@ TEST(CaptureVariables, SingleVariable3) {
 
   for (auto node : graph.op_nodes()) {
     auto node_name = node->name();
-    if (node_name == "Var")
-      ASSERT_NE("NGraphVariable", node->type_string());
-    else if (node_name == "Assign1")
-      ASSERT_NE("NGraphAssign", node->type_string());
-    else if (node_name == "Assign2")
-      ASSERT_NE("NGraphAssign", node->type_string());
-    else if (node_name == "Assign3")
-      ASSERT_NE("NGraphAssign", node->type_string());
+    if (node_name == "Var"){
+      ASSERT_NE("NGraphVariable", node->type_string());}
+    else if (node_name == "Assign1"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
+    else if (node_name == "Assign2"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
+    else if (node_name == "Assign3"){
+      ASSERT_NE("NGraphAssign", node->type_string());}
   }
 }
 

--- a/test/graph_rewrites/enter_in_catalog_test.cc
+++ b/test/graph_rewrites/enter_in_catalog_test.cc
@@ -93,6 +93,9 @@ TEST(CatalogTest, SmallGraph1) {
       ASSERT_TRUE(remove);
     }
   }
+
+  // Clean up
+  NGraphCatalog::ClearCatalog();
 }
 
 // Graph with Assign ops, one of which should not
@@ -137,6 +140,9 @@ TEST(CatalogTest, SmallGraph2) {
       ASSERT_TRUE(remove);
     }
   }
+
+  // Clean up
+  NGraphCatalog::ClearCatalog();
 }
 
 //  Const   Var_A      Const     Var_B
@@ -228,6 +234,9 @@ TEST(CatalogTest, SmallGraph3) {
       }
     }
   }
+
+  // Clean up
+  NGraphCatalog::ClearCatalog();
 }
 
 // Test to check if correct information is being added to the
@@ -283,6 +292,8 @@ TEST(CatalogTest, SmallGraph4) {
       }
     }
   }
+  // Clean up
+  NGraphCatalog::ClearCatalog();
 }
 
 }  // namespace testing

--- a/test/graph_rewrites/remove_ngraphassigns.cc
+++ b/test/graph_rewrites/remove_ngraphassigns.cc
@@ -463,6 +463,90 @@ TEST(RemoveNGraphAssigns, Graph5) {
   ASSERT_NOT_OK(RemoveNGraphAssigns(&graph));
 }
 
+// Graph with 2 Variables
+// This graph will throw an error
+//
+// Two NGraphVariables are being assigned the same value.
+// The ConstOp gets encapsulated and both the variables are being
+// assigned from the same output index of EncapsulateOp
+// Inside the encap op we create a vector of inputs and outputs
+// Technically, it is a single computed output that was designed to
+// be forwarded to two ops by TF.
+// On removing assigns, we directly pass the variable tensor as the output
+// tensor to enable the variable to be updated in place and avoid the copy
+// that is done later inside the Assign Op.
+// Since there is only one output, only one of the variable tensors
+// can be passed in the backend->call.
+// So only one of the variable gets updated, leading to functional
+// incorrectness.
+//
+// Few ideas to handle this:
+// 1. Do some additional bookeeping at the bridge in such cases
+// And update the other variables in the bridge
+// 2. Remove 1 assign, keep the assigns for other variables (might work)
+// 3. Manipulate the ng-function to mimic multiple outputs (if that is
+// possible).
+// We can then pass in all the variable tensors that need to be updated
+//
+// Right now we are throwing an error when we encounter a
+// scenario like this
+//
+// NGraphVariable1   Const      NGraphVariable2
+//   \               /  \            /
+//    \             /    \          /
+//    _\/         |/_     _\|     |/_
+//     NGraphAssign1       NGraphAssign2
+//         |                   |
+//        \|/                 \|/
+//        Retval1            Retval2
+//
+// The Const Op could be replaced with a computational subgraph
+// Const Op is used for demonstration purpose alone
+// Below is the graph after Assigns are removed
+//
+// NGraphVariabl1               NGraphVariable2
+//  \         \                    /
+//   \      ctrledge           ctrledge
+//    \        _\|               |/_
+//     \        NGraphEncapsulate
+//      \         /         \ 
+//       \     ctrledge     ctrledge
+//       _\|   \/_           _\|
+//        Retval1              Retval2
+//
+// Since NGraphEncapsulate can only update one tensor in place
+// we run into errors
+TEST(RemoveNGraphAssigns, Graph6) {
+  Scope root = Scope::NewRootScope();
+
+  PartialTensorShape varShape({2, 2});
+  auto var1 = ops::Variable(root.WithOpName("Var1"), varShape, DT_FLOAT);
+  auto init_value = ops::Const(root, {{1.f, 1.f}, {1.f, 1.f}});
+  auto var1_assign =
+      ops::Assign(root.WithOpName("Var1_Assign"), var1, init_value);
+
+  auto var2 = ops::Variable(root.WithOpName("Var2"), varShape, DT_FLOAT);
+  auto init_value2 = ops::Const(root, {{1.f, 1.f}, {1.f, 1.f}});
+  auto var2_assign =
+      ops::Assign(root.WithOpName("Var2_Assign"), var2, init_value2);
+
+  // Turn off optimizations so that all the nodes are processed
+  tensorflow::SessionOptions options;
+  options.config.mutable_graph_options()
+      ->mutable_optimizer_options()
+      ->set_opt_level(tensorflow::OptimizerOptions_Level_L0);
+  options.config.mutable_graph_options()
+      ->mutable_rewrite_options()
+      ->set_constant_folding(tensorflow::RewriterConfig::OFF);
+
+  // Run on nGraph
+  ActivateNGraph();
+  ClientSession ng_session(root, options);
+  std::vector<tensorflow::Tensor> ng_outputs1;
+
+  ASSERT_NOT_OK(ng_session.Run({var1_assign, var2_assign}, &ng_outputs1));
+}
+
 }  // namespace testing
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/test/graph_rewrites/test_replace_optimizer.cpp
+++ b/test/graph_rewrites/test_replace_optimizer.cpp
@@ -38,9 +38,6 @@ namespace ngraph_bridge {
 
 namespace testing {
 
-#define ASSERT_OK(x) ASSERT_EQ((x), ::tensorflow::Status::OK());
-#define ASSERT_NOT_OK(x) ASSERT_NE((x), ::tensorflow::Status::OK());
-
 // ReplaceModifier
 TEST(ReplaceModifierTest, Momentum2) {
   Scope root = Scope::NewRootScope();

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -66,7 +66,7 @@ void SetEnvVariable(const string& env_var_name, const string& env_var_val) {
 }
 
 // Store/Restore Env Variables
-const unordered_map<string, string> StoreEnv() {
+unordered_map<string, string> StoreEnv() {
   unordered_map<string, string> env_map;
   string env_name = "NGRAPH_TF_BACKEND";
   if (IsEnvVariableSet(env_name)) {
@@ -85,9 +85,7 @@ void RestoreEnv(const unordered_map<string, string>& map) {
 // NGRAPH_TF_BACKEND related
 bool IsNGraphTFBackendSet() { return IsEnvVariableSet("NGRAPH_TF_BACKEND"); }
 
-const string GetNGraphTFBackend() {
-  return GetEnvVariable("NGRAPH_TF_BACKEND");
-}
+string GetNGraphTFBackend() { return GetEnvVariable("NGRAPH_TF_BACKEND"); }
 
 void UnsetNGraphTFBackend() { UnsetEnvVariable("NGRAPH_TF_BACKEND"); }
 
@@ -96,7 +94,7 @@ void SetNGraphTFBackend(const string& backend_name) {
 }
 
 // Generating Seed for PseudoRandomNumberGenerator
-const unsigned int GetSeedForRandomFunctions() {
+unsigned int GetSeedForRandomFunctions() {
   const string& env_name = "NGRAPH_TF_SEED";
   unsigned int seed = static_cast<unsigned>(time(0));
   if (!IsEnvVariableSet(env_name)) {

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -38,7 +38,7 @@ void ActivateNGraph();
 void DeactivateNGraph();
 
 // Store/Restore Env Variables
-const unordered_map<string, string> StoreEnv();
+unordered_map<string, string> StoreEnv();
 void RestoreEnv(const unordered_map<string, string>& map);
 
 // EnvVariable Utilities
@@ -49,7 +49,7 @@ void SetEnvVariable(const string& env_var_name, const string& env_var_val);
 
 // NGRAPH_TF_BACKEND related
 bool IsNGraphTFBackendSet();
-const string GetNGraphTFBackend();
+string GetNGraphTFBackend();
 void UnsetNGraphTFBackend();
 void SetNGraphTFBackend(const string& bname);
 
@@ -60,7 +60,7 @@ void PrintTensorAllValues(
     int64 max_entries);  // print max_entries of elements in the Tensor
 
 // Generating Random Seed
-const unsigned int GetSeedForRandomFunctions();
+unsigned int GetSeedForRandomFunctions();
 
 // Assignment Functions
 // TODO : Retire AssignInputValuesAnchor and AssignInputValuesRandom


### PR DESCRIPTION
This PR is mainly to detect and throw an error in case a scenario like below is encountered.
Test : RemoveNGraphAssigns.Graph6

Two Variables are being updated with the same value --> by same output (output index) of Enacap Op.

Changes:
Catalog throws an error if an attempt is made to enter the same key again
Catalog api s are more robust (const added wherever required, replaced the use of [] operator by insert, at)