### PR TITLE
Sarkars/tf2ngraph infer out nodes

### DIFF
--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -29,7 +29,7 @@ import ngraph_bridge
 
 from tools.build_utils import command_executor
 from tools.tf2ngraph import update_config_to_include_custom_config,\
-guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
+get_possible_output_node_names, get_gdef_from_protobuf, sanitize_node_name
 
 from common import NgraphTest
 
@@ -69,10 +69,11 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
 
     @pytest.mark.parametrize(('filename'),
                              ('sample_graph.pbtxt', 'sample_graph.pb'))
-    def test_guess_output_nodes(self, filename):
-        assert guess_output_nodes(get_gdef_from_protobuf(filename)) == {
-            'out_node': 'Sigmoid'
-        }
+    def test_get_possible_output_node_names(self, filename):
+        assert get_possible_output_node_names(
+            get_gdef_from_protobuf(filename)) == {
+                'out_node': 'Sigmoid'
+            }
 
     @pytest.mark.parametrize(('node_name,sanitized_name'),
                              (('a', 'a'), ('b:3', 'b'), ('c:35', 'c'),

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -26,9 +26,10 @@ import numpy as np
 import shutil
 import tensorflow as tf
 import ngraph_bridge
+import mock
 
 from tools.build_utils import command_executor
-from tools.tf2ngraph import update_config_to_include_custom_config
+from tools.tf2ngraph import update_config_to_include_custom_config, guess_output_nodes, get_gdef_from_protobuf
 
 from common import NgraphTest
 
@@ -65,3 +66,9 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
             'device_id': '0',
             'aot_requested': '1'
         }
+
+    @pytest.mark.parametrize(('filename'),
+                             ('sample_graph.pbtxt','sample_graph.pb'))
+    def test_guess_output_nodes(self, filename):
+        with mock.patch('builtins.input', return_value="out_node"):
+            assert guess_output_nodes(get_gdef_from_protobuf(filename)) == ['out_node']

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -70,6 +70,9 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
     @pytest.mark.parametrize(('filename'),
                              ('sample_graph.pbtxt', 'sample_graph.pb'))
     def test_guess_output_nodes(self, filename):
+        # We expect guess_output_nodes to infer "out_node" as an output
+        # by monkey patching the "input" function to accept "out_node", we simulate a user entering a value
+        # Since "out_node" is a valid choice we expect guess_output_nodes to return with "out_node"
         with mock.patch('builtins.input', return_value="out_node"):
             assert guess_output_nodes(
                 get_gdef_from_protobuf(filename)) == ['out_node']
@@ -78,4 +81,5 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
                              (('a', 'a'), ('b:3', 'b'), ('c:35', 'c'),
                               ('^d', 'd'), ('^e:4', 'e')))
     def test_sanitize_node_name(self, node_name, sanitized_name):
+        # test to find node names by stripping away the control edge markers (^) and output slot numbers (:0)
         assert sanitize_node_name(node_name) == sanitized_name

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -28,7 +28,8 @@ import tensorflow as tf
 import ngraph_bridge
 
 from tools.build_utils import command_executor
-from tools.tf2ngraph import update_config_to_include_custom_config, guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
+from tools.tf2ngraph import update_config_to_include_custom_config,
+guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
 
 from common import NgraphTest
 

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -29,7 +29,7 @@ import ngraph_bridge
 import mock
 
 from tools.build_utils import command_executor
-from tools.tf2ngraph import update_config_to_include_custom_config, guess_output_nodes, get_gdef_from_protobuf
+from tools.tf2ngraph import update_config_to_include_custom_config, guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
 
 from common import NgraphTest
 
@@ -68,7 +68,14 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
         }
 
     @pytest.mark.parametrize(('filename'),
-                             ('sample_graph.pbtxt','sample_graph.pb'))
+                             ('sample_graph.pbtxt', 'sample_graph.pb'))
     def test_guess_output_nodes(self, filename):
         with mock.patch('builtins.input', return_value="out_node"):
-            assert guess_output_nodes(get_gdef_from_protobuf(filename)) == ['out_node']
+            assert guess_output_nodes(
+                get_gdef_from_protobuf(filename)) == ['out_node']
+
+    @pytest.mark.parametrize(('node_name,sanitized_name'),
+                             (('a', 'a'), ('b:3', 'b'), ('c:35', 'c'),
+                              ('^d', 'd'), ('^e:4', 'e')))
+    def test_sanitize_node_name(self, node_name, sanitized_name):
+        assert sanitize_node_name(node_name) == sanitized_name

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -28,7 +28,7 @@ import tensorflow as tf
 import ngraph_bridge
 
 from tools.build_utils import command_executor
-from tools.tf2ngraph import update_config_to_include_custom_config,
+from tools.tf2ngraph import update_config_to_include_custom_config,\
 guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
 
 from common import NgraphTest

--- a/test/python/test_tf2ngraph_functions.py
+++ b/test/python/test_tf2ngraph_functions.py
@@ -26,7 +26,6 @@ import numpy as np
 import shutil
 import tensorflow as tf
 import ngraph_bridge
-import mock
 
 from tools.build_utils import command_executor
 from tools.tf2ngraph import update_config_to_include_custom_config, guess_output_nodes, get_gdef_from_protobuf, sanitize_node_name
@@ -70,16 +69,14 @@ class Testtf2ngraphHelperFunctions(NgraphTest):
     @pytest.mark.parametrize(('filename'),
                              ('sample_graph.pbtxt', 'sample_graph.pb'))
     def test_guess_output_nodes(self, filename):
-        # We expect guess_output_nodes to infer "out_node" as an output
-        # by monkey patching the "input" function to accept "out_node", we simulate a user entering a value
-        # Since "out_node" is a valid choice we expect guess_output_nodes to return with "out_node"
-        with mock.patch('builtins.input', return_value="out_node"):
-            assert guess_output_nodes(
-                get_gdef_from_protobuf(filename)) == ['out_node']
+        assert guess_output_nodes(get_gdef_from_protobuf(filename)) == {
+            'out_node': 'Sigmoid'
+        }
 
     @pytest.mark.parametrize(('node_name,sanitized_name'),
                              (('a', 'a'), ('b:3', 'b'), ('c:35', 'c'),
                               ('^d', 'd'), ('^e:4', 'e')))
     def test_sanitize_node_name(self, node_name, sanitized_name):
-        # test to find node names by stripping away the control edge markers (^) and output slot numbers (:0)
+        # test to find node names by stripping away
+        # the control edge markers (^) and output slot numbers (:0)
         assert sanitize_node_name(node_name) == sanitized_name

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -47,13 +47,18 @@ class Testtf2ngraph(NgraphTest):
 
     @pytest.mark.parametrize(('commandline'),
                              (True,))  #TODO: add False for functional api test
-    @pytest.mark.parametrize(('inp_format', 'inp_loc', 'out_node_name'), (
-        ('pbtxt', 'sample_graph.pbtxt', 'out_node'),
-        ('savedmodel', 'sample_graph', 'out_node'),
-        ('pb', 'sample_graph.pb', 'out_node'),
-        ('pbtxt', 'sample_graph_nodevice.pbtxt', 'out_node'),
-        ('pbtxt', 'sample_graph_nodevice.pbtxt', None),
-    ))
+    @pytest.mark.parametrize(
+        ('inp_format', 'inp_loc', 'out_node_name'),
+        (
+            ('pbtxt', 'sample_graph.pbtxt', 'out_node'),
+            ('savedmodel', 'sample_graph', 'out_node'),
+            ('pb', 'sample_graph.pb', 'out_node'),
+            ('pbtxt', 'sample_graph_nodevice.pbtxt', 'out_node'),
+            ('pbtxt', 'sample_graph_nodevice.pbtxt', None),
+            # this test does not pass an output node
+            # and tf2ngraph is supposed to infer the output nodes
+            # and ask user to select one
+        ))
     @pytest.mark.parametrize(('out_format',), (
         ('pbtxt',),
         ('pb',),
@@ -144,10 +149,11 @@ class Testtf2ngraph(NgraphTest):
             assert np.isclose(res1, exp).all()
 
     def test_output_node_inference_for_saved_model(self):
-        # This saved model has input and output specified, and tf2ngraph should be able to infer it without user input
+        # The saved model we create in this pytest
+        # has input and output specified,
+        # and hence tf2ngraph should be able to infer it without user input
         export_dir = 'temp_pytest_savedmodel'
         out_loc = 'temp_pytest_pbtxt.pbtxt'
-        # TODO take care of file deletion
         try:
             shutil.rmtree(export_dir)
             os.remove(out_loc)

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -197,7 +197,7 @@ class Testtf2ngraph(NgraphTest):
         rc = p.returncode
 
         # Since no output nodes were provided, we expect tf2ngraph to print out possible output nodes
-        assert "Analysed graph for possible list of output nodes. " in output.decode(
+        assert "Analyzed graph for possible list of output nodes. " in output.decode(
         )
         assert "Please supply one or more output node in --output_nodes\n" in output.decode(
         )
@@ -226,7 +226,7 @@ class Testtf2ngraph(NgraphTest):
         output, err = p.communicate()
         rc = p.returncode
 
-        diagnostic_log = "Analysed graph for possible list of output nodes. " + \
+        diagnostic_log = "Analyzed graph for possible list of output nodes. " + \
         "Please supply one or more output node in --output_nodes\n" + \
         "output of type Softmax\n"
         assert diagnostic_log in output.decode()

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -201,8 +201,8 @@ class Testtf2ngraph(NgraphTest):
         )
         assert "Please supply one or more output node in --output_nodes\n" in output.decode(
         )
-        assert "output of type Softmax" in output.decode()
-        assert "add of type Add" in output.decode()
+        assert "Name: `output` Type: `Softmax`" in output.decode()
+        assert "Name: `add` Type: `Add`" in output.decode()
 
         # Since no output nodes were provided, we expect the test to fail with this error
         assert 'No output node name provided in --output_nodes' in err.decode()
@@ -228,7 +228,7 @@ class Testtf2ngraph(NgraphTest):
 
         diagnostic_log = "Analyzed graph for possible list of output nodes. " + \
         "Please supply one or more output node in --output_nodes\n" + \
-        "output of type Softmax\n"
+        "Name: `output` Type: `Softmax`\n"
         assert diagnostic_log in output.decode()
         assert 'No output node name provided in --output_nodes' in err.decode()
         assert rc != 0

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -97,8 +97,8 @@ class Testtf2ngraph(NgraphTest):
             if commandline:
                 # In CI this test is expected to be run out of artifacts/test/python
                 # out_node_str is empty if out_node_name is None.
-                # Automatic output node inference is supposed to kick in that case.
-                # we monkeypatch the builtin function input to simulate an user input
+                # Automatic output node inference display diagnostic logs
+                # But the tf2ngraph call will still fail
                 out_node_str = ' ' if out_node_name is None else ' --output_nodes ' + out_node_name + ' '
                 try:
                     command_executor(
@@ -188,8 +188,8 @@ class Testtf2ngraph(NgraphTest):
         rc = p.returncode
 
         # Since no output nodes were provided, we expect tf2ngraph to print out possible output nodes
-        assert "Analysed graph for possible list of output nodes. Please supply one or more output node in --output_nodes\noutput of type Softmax\nadd of type Add\n" in output.decode(
-        )
+        diagnostic_log = "Analysed graph for possible list of output nodes. Please supply one or more output node in --output_nodes\noutput of type Softmax\nadd of type Add\n"
+        assert diagnostic_log in output.decode()
 
         # Since no output nodes were provided, we expect the test to fail with this error
         assert 'No output node name provided in --output_nodes' in err.decode()
@@ -213,8 +213,7 @@ class Testtf2ngraph(NgraphTest):
         output, err = p.communicate()
         rc = p.returncode
 
-        assert "Analysed graph for possible list of output nodes. Please supply one or more output node in --output_nodes\noutput of type Softmax\nadd of type Add\n" in output.decode(
-        )
+        assert diagnostic_log in output.decode()
         assert 'No output node name provided in --output_nodes' in err.decode()
         assert rc != 0
 

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -191,10 +191,12 @@ class Testtf2ngraph(NgraphTest):
         rc = p.returncode
 
         # Since no output nodes were provided, we expect tf2ngraph to print out possible output nodes
-        diagnostic_log = "Analysed graph for possible list of output nodes. " + \
-        "Please supply one or more output node in --output_nodes\n" + \
-        "output of type Softmax\nadd of type Add\n"
-        assert diagnostic_log in output.decode()
+        assert "Analysed graph for possible list of output nodes. " in output.decode(
+        )
+        assert "Please supply one or more output node in --output_nodes\n" in output.decode(
+        )
+        assert "output of type Softmax" in output.decode()
+        assert "add of type Add" in output.decode()
 
         # Since no output nodes were provided, we expect the test to fail with this error
         assert 'No output node name provided in --output_nodes' in err.decode()

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -198,9 +198,8 @@ class Testtf2ngraph(NgraphTest):
         assert rc != 0
 
         shutil.rmtree(export_dir_saved_model)
-        os.remove(tf2ngraph_out_loc)
 
-        # In case or normal pb or pbtxt or saved mdoels without signature_def
+        # In case or normal pb or pbtxt or saved models without signature_def
         # we rely on our code (guess_output_nodes) to guess output nodes
         # The following test tests the guess_output_nodes code path
 
@@ -220,4 +219,3 @@ class Testtf2ngraph(NgraphTest):
         assert rc != 0
 
         os.remove(export_pbtxt)
-        os.remove(tf2ngraph_out_loc)

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -67,7 +67,8 @@ class Testtf2ngraph(NgraphTest):
     @pytest.mark.parametrize(('ng_device', 'shape_hints', 'precompile'),
                              (('CPU', [], False), ('INTERPRETER', [{}], True),
                               ('INTERPRETER', [], False)))
-    # In sample_graph.pbtxt, the input shape is fully specified, so we don't need to pass shape hints for precompile
+    # In sample_graph.pbtxt, the input shape is fully specified,
+    # so we don't need to pass shape hints for precompile
     def test_command_line_api(self, inp_format, inp_loc, out_node_name,
                               out_format, commandline, ng_device, shape_hints,
                               precompile):
@@ -99,7 +100,10 @@ class Testtf2ngraph(NgraphTest):
                 # out_node_str is empty if out_node_name is None.
                 # Automatic output node inference display diagnostic logs
                 # But the tf2ngraph call will still fail
-                out_node_str = ' ' if out_node_name is None else ' --output_nodes ' + out_node_name + ' '
+                if out_node_name is None:
+                    out_node_str = ' '
+                else:
+                    out_node_str = ' --output_nodes ' + out_node_name + ' '
                 try:
                     command_executor(
                         'python ../../tools/tf2ngraph.py --input_' +
@@ -108,7 +112,8 @@ class Testtf2ngraph(NgraphTest):
                         ' --ng_backend ' + ng_device + ' --config_file ' +
                         config_file_name + ("", " --precompile ")[precompile])
                 except:
-                    assert out_node_name is None, "Call to tf2ngraph should fail when no output name is provided"
+                    assert out_node_name is None, "Call to tf2ngraph should fail" + \
+                    " when no output name is provided"
                     return
             else:
                 convert(inp_format, inp_loc, out_format, out_loc, ['out_node'],

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -188,7 +188,9 @@ class Testtf2ngraph(NgraphTest):
         rc = p.returncode
 
         # Since no output nodes were provided, we expect tf2ngraph to print out possible output nodes
-        diagnostic_log = "Analysed graph for possible list of output nodes. Please supply one or more output node in --output_nodes\noutput of type Softmax\nadd of type Add\n"
+        diagnostic_log = "Analysed graph for possible list of output nodes. " + \
+        "Please supply one or more output node in --output_nodes\n" +\
+        "output of type Softmax\nadd of type Add\n"
         assert diagnostic_log in output.decode()
 
         # Since no output nodes were provided, we expect the test to fail with this error

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -29,7 +29,7 @@ import ngraph_bridge
 from subprocess import Popen, PIPE
 
 from tools.build_utils import command_executor
-from tools.tf2ngraph import convert, get_gdef, Tf2ngraphJson, get_gdef_from_protobuf
+from tools.tf2ngraph import convert, get_gdef, Tf2ngraphJson
 
 from common import NgraphTest
 

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -192,7 +192,7 @@ class Testtf2ngraph(NgraphTest):
 
         # Since no output nodes were provided, we expect tf2ngraph to print out possible output nodes
         diagnostic_log = "Analysed graph for possible list of output nodes. " + \
-        "Please supply one or more output node in --output_nodes\n" +\
+        "Please supply one or more output node in --output_nodes\n" + \
         "output of type Softmax\nadd of type Add\n"
         assert diagnostic_log in output.decode()
 
@@ -218,6 +218,9 @@ class Testtf2ngraph(NgraphTest):
         output, err = p.communicate()
         rc = p.returncode
 
+        diagnostic_log = "Analysed graph for possible list of output nodes. " + \
+        "Please supply one or more output node in --output_nodes\n" + \
+        "output of type Softmax\n"
         assert diagnostic_log in output.decode()
         assert 'No output node name provided in --output_nodes' in err.decode()
         assert rc != 0

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -208,8 +208,8 @@ class Testtf2ngraph(NgraphTest):
         shutil.rmtree(export_dir_saved_model)
 
         # In case or normal pb or pbtxt or saved models without signature_def
-        # we rely on our code (guess_output_nodes) to guess output nodes
-        # The following test tests the guess_output_nodes code path
+        # we rely on our code (get_possible_output_node_names) to guess output nodes
+        # The following test tests the get_possible_output_node_names code path
 
         p = Popen([
             'python', '../../tools/tf2ngraph.py', '--input_pbtxt', export_pbtxt,

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -109,6 +109,7 @@ class Testtf2ngraph(NgraphTest):
                         config_file_name + ("", " --precompile ")[precompile])
                 except:
                     assert out_node_name is None, "Call to tf2ngraph should fail when no output name is provided"
+                    return
             else:
                 convert(inp_format, inp_loc, out_format, out_loc, ['out_node'],
                         ng_device, optional_backend_params, shape_hints,

--- a/test/python/test_tf2ngraph_script.py
+++ b/test/python/test_tf2ngraph_script.py
@@ -154,6 +154,9 @@ class Testtf2ngraph(NgraphTest):
         # The saved model we create in this pytest
         # has input and output specified,
         # and hence tf2ngraph should be able to infer it without user input
+        # In this test we do not pass --output_nodes and parse the logs to
+        # ensure that diagnostic logs have been printed
+        # from tf2ngraph indicating the output nodes
         export_dir_saved_model = 'temp_pytest_savedmodel_orig'
         export_pbtxt = 'temp_pytest_pbtxt_orig.pbtxt'
         tf2ngraph_out_loc = 'temp_pytest_pbtxt_tf2ngraph.pbtxt'

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -259,7 +259,10 @@ def filter_dict(prefix, dictionary):
             lambda x: x.startswith(prefix + '_') and dictionary[x] is not None
             and 'nodes' not in x, dictionary))
     assert len(current_format) == 1, "Got " + str(
-        len(current_format)) + " " + prefix + " formats, expected only 1"
+        len(current_format)
+    ) + " " + prefix + " formats, expected only 1. Please add --" + prefix + \
+    "_pb or --" + prefix + "_pbtxt or --" + prefix + "_savedmodel and pass the " + \
+    prefix + " model location"
     # [len(prefix):] deletes the initial "input" in the string
     stripped = current_format[0][len(prefix):].lstrip('_')
     assert stripped in allowed_formats[

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -229,7 +229,8 @@ def prepare_argparser(formats):
         "Comma separated list of output nodes. Output nodes can be found " \
         "by manual inspection of the graph, prior knowledge or running the " \
         "summarize_graph tool provided by Tensorflow",
-        required=True)
+        required=False,
+        default=None)
     parser.add_argument(
         "--ng_backend", default='CPU', help="Ngraph backend. Eg, NNPI")
     parser.add_argument("--device_id", default='', help="Device id. Eg, 0")
@@ -333,6 +334,14 @@ def convert(inp_format, inp_loc, out_format, out_loc, output_nodes, ng_backend,
         backend_optional_params, shape_hints, do_aot)
     save_model(output_gdef, out_format, out_loc)
 
+def get_output_nodes(output_nodes):
+    if type(output_nodes) == type(""):
+        output_nodes.split(',')
+    elif output_nodes is None:
+        pass
+        # TODO
+    else:
+        raise ValueError('get_output_nodes called with argument of type ', type(output_nodes), " but it can only accept string or None")
 
 def main():
     """ Entry point of command line api for converting TF models by inserting ngraph nodes.
@@ -343,7 +352,7 @@ def main():
     args = prepare_argparser(allowed_formats)
     inp_format, inp_loc = filter_dict("input", args.__dict__)
     out_format, out_loc = filter_dict("output", args.__dict__)
-    output_nodes = args.output_nodes.split(',')
+    output_nodes = get_output_nodes(args.output_nodes)
     backend_optional_params, shape_hints = Tf2ngraphJson.parse_json(
         args.config_file)
     convert(inp_format, inp_loc, out_format, out_loc, output_nodes,
@@ -354,9 +363,5 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-    # TODO remove these lines
-    # python tf2ngraph.py --input_pbtxt ../test/test_axpy.pbtxt --output_nodes add --output_pbtxt axpy_ngraph.pbtxt --ng_backend INTERPRETER --config_file sample_optional_params_and_shape_hints.json --precompile
-    # python run_tf2ngraph_model.py
 
     # TODO what happens if same shape is passed twice

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -336,6 +336,9 @@ def convert(inp_format, inp_loc, out_format, out_loc, output_nodes, ng_backend,
 
 
 def sanitize_node_name(node_name):
+    '''
+    Given an input to a node in the graph def clean it to find the node name
+    '''
     # get rid of caret indicating control edge (^name -> name)
     if node_name.startswith('^'):
         node_name = node_name[1:]
@@ -350,6 +353,9 @@ def sanitize_node_name(node_name):
 
 
 def guess_output_nodes(graph_def):
+    '''
+    Given a graph def guess the outputs and ask user to select one from the candidates
+    '''
     node_name_type_dict = {n.name: n.op for n in graph_def.node}
     nodes_which_appear_at_inputs = set()
     for n in graph_def.node:
@@ -369,8 +375,8 @@ def guess_output_nodes(graph_def):
             "Please enter a comma separated string of output names: ")
         if not set(out_node_names.split(',')).issubset(possible_outputs):
             print(
-                'Entered ', out_node_names,
-                ', but it contains names not present in the suggested output node name list. Please try again'
+                'Please try again. Entered ', out_node_names,
+                ', but it contains names not present in the suggested output node name list.'
             )
         else:
             break
@@ -378,6 +384,11 @@ def guess_output_nodes(graph_def):
 
 
 def get_output_nodes(output_nodes, inp_format, inp_loc):
+    '''
+    Either process the given string from the user,
+    or try to read output names from savedmodel's signature_def
+    or try to guess the outputs (with user's inputs)
+    '''
     if type(output_nodes) == type(""):
         return output_nodes.split(',')
     elif output_nodes is None:

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -98,10 +98,10 @@ class Tf2ngraphJson(object):
 
 
 # This function controls how errors are handled.
-# For developers/debugging set raise_exception to True
-def exit_on_error(success, error_message, raise_exception=False):
+# For developers/debugging set assert_on_failure to True
+def exit_on_error(success, error_message, assert_on_failure=False):
     if not success:
-        if raise_exception:
+        if assert_on_failure:
             sys.stderr.write("\n" + error_message + "\n")
             sys.exit(1)
         else:

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -387,11 +387,15 @@ def get_output_nodes(output_nodes, inp_format, inp_loc):
                     sess,
                     tags=[tf.saved_model.tag_constants.SERVING],
                     export_dir=inp_loc)
-                print(imported.signature_def)
-                raise NotImplemented("TODO:")
-                # TODO:
-                if False:  # TODO: could be empty. in that case go back to guessing
-                    pass
+                try:
+                    output_info = imported.signature_def[
+                        'serving_default'].outputs.values()
+                    saved_model_has_out_name = True
+                except:
+                    saved_model_has_out_name = False
+                if saved_model_has_out_name:
+                    # the list comprehension gets the naes from the output_info of type collections.abc.ValuesView
+                    return [sanitize_node_name(i.name) for i in output_info]
                 else:
                     return guess_output_nodes(sess.graph_def)
         elif inp_format == 'pbtxt' or inp_format == 'pb':

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -389,11 +389,10 @@ def get_output_nodes(output_nodes, inp_format, inp_loc):
                     sess,
                     tags=[tf.saved_model.tag_constants.SERVING],
                     export_dir=inp_loc)
-                import pdb
-                pdb.set_trace()
                 print(imported.signature_def)
+                raise NotImplemented("TODO:")
                 # TODO:
-                if False:  # could be empty. in that case go back to guessing
+                if False:  # TODO: could be empty. in that case go back to guessing
                     pass
                 else:
                     return guess_output_nodes(sess.graph_def)

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -336,8 +336,6 @@ def convert(inp_format, inp_loc, out_format, out_loc, output_nodes, ng_backend,
 
 
 def sanitize_node_name(node_name):
-    # TODO test this function
-
     # get rid of caret indicating control edge (^name -> name)
     if node_name.startswith('^'):
         node_name = node_name[1:]

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -380,11 +380,13 @@ def infer_output_nodes(inp_format, inp_loc):
     '''
     if inp_format == 'savedmodel':
         with tf.Session(graph=tf.Graph()) as sess:
+            # load the saved model
             imported = tf.saved_model.load(
                 sess,
                 tags=[tf.saved_model.tag_constants.SERVING],
                 export_dir=inp_loc)
             try:
+                # Check if the saved model has outputs specified
                 output_info = imported.signature_def[
                     'serving_default'].outputs.values()
                 saved_model_has_out_name = True
@@ -399,6 +401,8 @@ def infer_output_nodes(inp_format, inp_loc):
                 node_name_type_dict = get_name_type_map(imported.graph_def)
                 return {k: node_name_type_dict[k] for k in possible_outputs}
             else:
+                # Outputs not specified in the saved model
+                # Hence using guess_output_nodes
                 return guess_output_nodes(sess.graph_def)
     elif inp_format == 'pbtxt' or inp_format == 'pb':
         return guess_output_nodes(get_gdef_from_protobuf(inp_loc))

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -425,7 +425,7 @@ def main():
     if args.output_nodes is None:
         possible_out_nodes = infer_output_nodes(inp_format, inp_loc)
         print(
-            "\nAnalyzed graph for possible list of output nodes." + \
+            "\nAnalyzed graph for possible list of output nodes. " + \
             "Please supply one or more output node in --output_nodes"
         )
         for out_node in possible_out_nodes:

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -283,11 +283,10 @@ def filter_dict(prefix, dictionary):
         filter(
             lambda x: x.startswith(prefix + '_') and dictionary[x] is not None
             and 'nodes' not in x, dictionary))
-    exit_on_error(len(current_format) == 1, "Got " + str(
-        len(current_format)
-    ) + " " + prefix + " formats, expected only 1. Please add --" + prefix + \
-    "_pb or --" + prefix + "_pbtxt or --" + prefix + "_savedmodel and pass the " + \
-    prefix + " model location")
+    exit_on_error(len(current_format) == 1, "Got " + str(len(current_format)) + \
+    " " + prefix + " formats, expected exactly 1 " + prefix + \
+    " format. Please add one of --" + prefix + "_pb or --" + prefix + \
+    "_pbtxt or --" + prefix + "_savedmodel and pass the " + prefix + " model location")
     # [len(prefix):] deletes the initial "input" in the string
     stripped = current_format[0][len(prefix):].lstrip('_')
     exit_on_error(

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -97,7 +97,7 @@ class Tf2ngraphJson(object):
             json.dump(dict_to_dump, fp)
 
 
-# This fucntion controls how errors are handled.
+# This function controls how errors are handled.
 # For developers/debugging set raise_exception to True
 def exit_on_error(success, error_message, raise_exception=False):
     if not success:

--- a/tools/tf2ngraph.py
+++ b/tools/tf2ngraph.py
@@ -336,9 +336,13 @@ def convert(inp_format, inp_loc, out_format, out_loc, output_nodes, ng_backend,
 
 
 def sanitize_node_name(node_name):
-    # Remove :0 or ctrl edge ^ etc
     # TODO test this function
-    raise NotImplemented("TODO implement me")
+
+    # get rid of caret indicating control edge
+    if node_name.startswith('^'):
+        node_name = node_name[1:]
+    raise NotImplemented("TODO implement me") # TODO: Remove :0
+    return node_name
 
 
 def guess_output_nodes(graph_def):


### PR DESCRIPTION
Make `--output_nodes` optional in `tf2ngraph` and in case it is not passed, print suggested output node names before failing


How to find output nodes:
1. For saved models that have output node info saved, parse the signaturedef to infer the output names
2. For others scan the graph to find nodes which are not input to other nodes and provide a list of suggested output nodes


Sample output for `python tf2ngraph.py --input_pbtxt ../test/test_axpy.pbtxt --output_pbtxt axpy_ngraph.pbtxt` (no --output_nodes passed)
```
Analysed graph for possible list of output nodes. Please supply one or more output node in --output_nodes
add of type Add
Traceback (most recent call last):
  File "tf2ngraph.py", line 443, in <module>
    main()
  File "tf2ngraph.py", line 431, in main
    raise ValueError("No output node name provided in --output_nodes")
ValueError: No output node name provided in --output_nodes

```


Also replace `assert`s and `raise`s by `exit_on_error`. `exit_on_error` (by default) prints the last error message and not the whole stack trace which is easier to read/understand UX-wise. Also expanded some error messages.