### PR TITLE
sarkars/resize bilinear for r19

### DIFF
--- a/bazel/ngraph.BUILD
+++ b/bazel/ngraph.BUILD
@@ -57,6 +57,7 @@ cc_library(
         "src/ngraph/op/experimental/quantized_dot_bias.cpp",
         "src/ngraph/op/experimental/tile.cpp",
         "src/ngraph/op/experimental/transpose.cpp",
+        "src/ngraph/op/experimental/layers/interpolate.cpp",
         "src/ngraph/op/util/*.cpp",
         "src/ngraph/pattern/*.cpp",
         "src/ngraph/pattern/*.hpp",

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -26,6 +26,7 @@
 #include "ngraph/builder/quantization.hpp"
 #include "ngraph/op/argmax.hpp"
 #include "ngraph/op/argmin.hpp"
+#include "ngraph/op/experimental/layers/interpolate.hpp"
 #include "ngraph/op/util/logical_reduction.hpp"
 
 #include "logging/ngraph_log.h"
@@ -3693,6 +3694,33 @@ static Status TranslateReshapeOp(
   SaveNgOp(ng_op_map, op->name(),
            ConstructNgNode<ng::op::Reshape>(op->name(), ng_input, ng_axis_order,
                                             ng_shape));
+  return Status::OK();
+}
+
+static Status TranslateResizeBilinearOp(
+    const Node* op, const std::vector<const Tensor*>& static_input_map,
+    Builder::OpMap& ng_op_map) {
+  shared_ptr<ng::Node> images, size;
+  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &images, &size));
+
+  bool align_corners;
+  TF_RETURN_IF_ERROR(GetNodeAttr(op->attrs(), "align_corners", &align_corners));
+
+  ngraph::op::InterpolateAttrs attrs;
+  attrs.align_corners = align_corners;
+  attrs.mode = "linear";
+  attrs.antialias = false;
+  // The TF "images" is has dimensions [batch, height, width, channels].
+  // So 1 and 2 are the spatial axes
+  // TODO check this parameter
+  attrs.axes = {1, 2};
+  // TODO: pads_begin and pads_end are not populated. Check correctness
+
+  auto size_int64 =
+      ConstructNgNode<ng::op::Convert>(op->name(), size, ngraph::element::i64);
+  SaveNgOp(ng_op_map, op->name(), ConstructNgNode<ng::op::Interpolate>(
+                                      op->name(), images, size_int64, attrs));
+
   return Status::OK();
 }
 

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -367,6 +367,8 @@ Status MarkForClustering(Graph* graph, const std::set<string> skip_these_nodes,
       confirmation_function_map["Relu6"] = SimpleConfirmationFunction();
       confirmation_function_map["ReluGrad"] = SimpleConfirmationFunction();
       confirmation_function_map["Reshape"] = SimpleConfirmationFunction();
+      confirmation_function_map["ResizeBilinear"] =
+          SimpleConfirmationFunction();
       confirmation_function_map["Rsqrt"] = SimpleConfirmationFunction();
       confirmation_function_map["RsqrtGrad"] = SimpleConfirmationFunction();
       confirmation_function_map["Select"] = SimpleConfirmationFunction();
@@ -563,6 +565,7 @@ Status MarkForClustering(Graph* graph, const std::set<string> skip_these_nodes,
       type_constraint_map["ReluGrad"]["T"] = NGraphNumericDTypes();
       type_constraint_map["Reshape"]["T"] = NGraphDTypes();
       type_constraint_map["Reshape"]["Tshape"] = NGraphIndexDTypes();
+      type_constraint_map["ResizeBilinear"]["T"] = NGraphNumericDTypes();
       type_constraint_map["Rsqrt"]["T"] = NGraphDTypes();
       type_constraint_map["RsqrtGrad"]["T"] = NGraphRealDTypes();
       type_constraint_map["Select"]["T"] = NGraphDTypes();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SRC
     graph_rewrites/mark_for_clustering_test.cc
     test_index_library.cpp
     test_utilities.cpp
+    test_image_ops.cpp
     test_math_ops.cpp
     test_nn_ops.cpp
     test_array_ops.cpp

--- a/test/test_image_ops.cpp
+++ b/test/test_image_ops.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2017-2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include "test/opexecuter.h"
+
+using namespace std;
+namespace ng = ngraph;
+
+namespace tensorflow {
+
+namespace ngraph_bridge {
+
+namespace testing {
+
+// Test op: ResizeBilinear
+// Disabled till a backend starts supporting it
+TEST(ImageOps, DISABLED_ResizeBilinear) {
+  for (auto align : {true, false}) {
+    Scope root = Scope::NewRootScope();
+    // [batch, height, width, channels]
+    Tensor images(DT_FLOAT, TensorShape({4, 64, 64, 3}));
+    AssignInputValuesRandom(images);
+
+    // Todo: test by changing align_corners
+
+    // new_height, new_width
+    Tensor size(DT_INT32, TensorShape({2}));
+    vector<int> new_dims = {93, 27};
+    // TODO loop and do multiple sizes, larger
+    // and smaller than original
+    AssignInputValues(size, new_dims);
+
+    auto attr = ops::ResizeBilinear::Attrs().AlignCorners(align);
+
+    vector<int> static_input_indexes = {};
+    auto R = ops::ResizeBilinear(root, images, size, attr);
+    vector<DataType> output_datatypes = {DT_FLOAT};
+
+    std::vector<Output> sess_run_fetchoutputs = {R};
+    OpExecuter opexecuter(root, "ResizeBilinear", static_input_indexes,
+                          output_datatypes, sess_run_fetchoutputs);
+
+    opexecuter.RunTest();
+  }
+}
+}
+}
+}


### PR DESCRIPTION
resizebilinear translation. uses ngraph op "interpolate", but that has no implementation in any backend, so gtest is disabled for now.

There are some TODOs in the PR, to be done when we have backends start supporting interpolate.