### PR TITLE
sarkars/Fix int32-int64 issue. Removing convert op

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -3735,8 +3735,15 @@ static Status TranslateReshapeOp(
 static Status TranslateResizeBilinearOp(
     const Node* op, const std::vector<const Tensor*>& static_input_map,
     Builder::OpMap& ng_op_map) {
-  shared_ptr<ng::Node> images, size;
-  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &images, &size));
+  shared_ptr<ng::Node> images;
+  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &images, nullptr));
+
+  std::vector<int32> size_vector;
+  TF_RETURN_IF_ERROR(
+      GetStaticInputVector(op, 1, static_input_map, &size_vector));
+
+  auto size_int64 = ConstructNgNode<ng::op::Constant>(
+      op->name(), ngraph::element::i64, ng::Shape{2}, size_vector);
 
   bool align_corners;
   TF_RETURN_IF_ERROR(GetNodeAttr(op->attrs(), "align_corners", &align_corners));
@@ -3751,8 +3758,6 @@ static Status TranslateResizeBilinearOp(
   attrs.axes = {1, 2};
   // TODO: pads_begin and pads_end are not populated. Check correctness
 
-  auto size_int64 =
-      ConstructNgNode<ng::op::Convert>(op->name(), size, ngraph::element::i64);
   SaveNgOp(ng_op_map, op->name(), ConstructNgNode<ng::op::Interpolate>(
                                       op->name(), images, size_int64, attrs));
 

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -656,6 +656,7 @@ Status MarkForClustering(Graph* graph, const std::set<string> skip_these_nodes,
         return Status::OK();
       };
       set_attributes_map["Reshape"] = SetStaticInputs({1});
+      set_attributes_map["ResizeBilinear"] = SetStaticInputs({1});
       set_attributes_map["ScatterNd"] = SetStaticInputs({2});
       set_attributes_map["Slice"] = SetStaticInputs({1, 2});
       set_attributes_map["Split"] = SetStaticInputs({0});


### PR DESCRIPTION
resizebilinear has a 4d input and a 2d output size.

Making the output size "static" so that it can only be fed by a constant (else a split occurs)
Also removing the "convert" op

Earlier the ngraph function looked like: const(outshape)->convert(i32 to i64)->resizebilinear

now it looks like:
const(outputshape) --> resizebilinear

