### PR TITLE
Jitendra/fix for mem leak

### DIFF
--- a/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
@@ -226,8 +226,12 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
 
     // 4. Encapsulate clusters then, if requested, dump the graphs.
     FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
-    TF_RETURN_IF_ERROR(EncapsulateClusters(options.graph->get(), idx,
-                                           fdeflib_new, config_map, {0, {}}));
+    auto status = EncapsulateClusters(options.graph->get(), idx,
+                                      fdeflib_new, config_map, {0, {}});
+    if(status != Status::OK()){
+      delete (fdeflib_new);
+      return status;
+    }
     // TODO: not using fdeflib_new in this path. Only grappler path uses it
     free(fdeflib_new);
     if (DumpEncapsulatedGraphs()) {

--- a/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/enable_variable_ops/ngraph_rewrite_pass.cc
@@ -226,9 +226,9 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
 
     // 4. Encapsulate clusters then, if requested, dump the graphs.
     FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
-    auto status = EncapsulateClusters(options.graph->get(), idx,
-                                      fdeflib_new, config_map, {0, {}});
-    if(status != Status::OK()){
+    auto status = EncapsulateClusters(options.graph->get(), idx, fdeflib_new,
+                                      config_map, {0, {}});
+    if (status != Status::OK()) {
       delete (fdeflib_new);
       return status;
     }

--- a/ngraph_bridge/grappler/ngraph_optimizer.cc
+++ b/ngraph_bridge/grappler/ngraph_optimizer.cc
@@ -260,9 +260,12 @@ Status NgraphOptimizer::Optimize(tensorflow::grappler::Cluster* cluster,
 
   // 4. Encapsulate clusters then, if requested, dump the graphs.
   FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
-  TF_RETURN_IF_ERROR(
-      // TODO: right now _ngraph_aot_requested is passed along in config_map.
-      EncapsulateClusters(&graph, idx, fdeflib_new, config_map, aot_info));
+  // TODO: right now _ngraph_aot_requested is passed along in config_map.
+  auto status = EncapsulateClusters(&graph, idx, fdeflib_new, config_map, aot_info);
+  if (status != Status::OK()) {
+    delete (fdeflib_new);
+    return status;
+  }
   if (DumpEncapsulatedGraphs()) {
     DumpGraphs(graph, idx, "encapsulated", "Graph with Clusters Encapsulated");
   }

--- a/ngraph_bridge/grappler/ngraph_optimizer.cc
+++ b/ngraph_bridge/grappler/ngraph_optimizer.cc
@@ -261,7 +261,8 @@ Status NgraphOptimizer::Optimize(tensorflow::grappler::Cluster* cluster,
   // 4. Encapsulate clusters then, if requested, dump the graphs.
   FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
   // TODO: right now _ngraph_aot_requested is passed along in config_map.
-  auto status = EncapsulateClusters(&graph, idx, fdeflib_new, config_map, aot_info);
+  auto status =
+      EncapsulateClusters(&graph, idx, fdeflib_new, config_map, aot_info);
   if (status != Status::OK()) {
     delete (fdeflib_new);
     return status;

--- a/ngraph_bridge/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/ngraph_rewrite_pass.cc
@@ -232,7 +232,7 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
     FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
     auto status = EncapsulateClusters(options.graph->get(), idx,
                                       fdeflib_new, config_map, {0, {}});
-    if(status != Status::OK){
+    if(status != Status::OK()){
       delete (fdeflib_new);
       return status;
     }

--- a/ngraph_bridge/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/ngraph_rewrite_pass.cc
@@ -230,9 +230,9 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
 
     // 4. Encapsulate clusters then, if requested, dump the graphs.
     FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
-    auto status = EncapsulateClusters(options.graph->get(), idx,
-                                      fdeflib_new, config_map, {0, {}});
-    if(status != Status::OK()){
+    auto status = EncapsulateClusters(options.graph->get(), idx, fdeflib_new,
+                                      config_map, {0, {}});
+    if (status != Status::OK()) {
       delete (fdeflib_new);
       return status;
     }

--- a/ngraph_bridge/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/ngraph_rewrite_pass.cc
@@ -230,8 +230,12 @@ class NGraphEncapsulationPass : public NGraphRewritePass {
 
     // 4. Encapsulate clusters then, if requested, dump the graphs.
     FunctionDefLibrary* fdeflib_new = new FunctionDefLibrary();
-    TF_RETURN_IF_ERROR(EncapsulateClusters(options.graph->get(), idx,
-                                           fdeflib_new, config_map, {0, {}}));
+    auto status = EncapsulateClusters(options.graph->get(), idx,
+                                      fdeflib_new, config_map, {0, {}});
+    if(status != Status::OK){
+      delete (fdeflib_new);
+      return status;
+    }
     // TODO: not using fdeflib_new in this path. Only grappler path uses it
     delete (fdeflib_new);
     if (DumpEncapsulatedGraphs()) {


### PR DESCRIPTION
Fix for potential memory leak. 
`FunctionDefLibrary` object memory is not freed in case of errors occurs. This PR fixes this issue.