### PR TITLE
Avoid setting local dict when calling exec() to activate venv

### DIFF
--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -123,7 +123,7 @@ def load_venv(venv_dir):
     exec(
         compile(
             open(activate_this_file, "rb").read(), activate_this_file, 'exec'),
-        dict(__file__=activate_this_file), dict(__file__=activate_this_file))
+        dict(__file__=activate_this_file))
 
     return venv_dir
 


### PR DESCRIPTION
Calling activate_this.py using exec() fails for virtualenv > 16.1.0 as we pass
a "locals" dict overriding the functions locals. This patch fixes the failure
to activate virtualenv during build_ngtf.py for virtualenv > 16.1.0.

Fixes #383