### PR TITLE
Peg TF and NGraph models to specific versions

### DIFF
--- a/test/model_level_tests/models/ngraph-models/repo.txt
+++ b/test/model_level_tests/models/ngraph-models/repo.txt
@@ -1,1 +1,2 @@
 https://github.com/NervanaSystems/ngraph-models.git
+v1.14

--- a/test/model_level_tests/models/tfmodels/enable_ngraph.patch
+++ b/test/model_level_tests/models/tfmodels/enable_ngraph.patch
@@ -1,17 +1,17 @@
 diff --git a/official/resnet/cifar10_main.py b/official/resnet/cifar10_main.py
-index 51e16161..b49094dd 100644
+index e5e5008f..edfe77dc 100644
 --- a/official/resnet/cifar10_main.py
 +++ b/official/resnet/cifar10_main.py
-@@ -28,6 +28,7 @@ from official.utils.flags import core as flags_core
- from official.utils.logs import logger
- from official.resnet import resnet_model
+@@ -28,6 +28,7 @@ from official.resnet import resnet_model
  from official.resnet import resnet_run_loop
+ from official.utils.flags import core as flags_core
+ from official.utils.logs import logger
 +import ngraph_bridge
  
  HEIGHT = 32
  WIDTH = 32
-@@ -239,10 +240,11 @@ def define_cifar_flags():
-   flags_core.set_defaults(data_dir='/tmp/cifar10_data',
+@@ -237,10 +238,11 @@ def define_cifar_flags():
+   flags_core.set_defaults(data_dir='/tmp/cifar10_data/cifar-10-batches-bin',
                            model_dir='/tmp/cifar10_model',
                            resnet_size='56',
 -                          train_epochs=182,

--- a/test/model_level_tests/models/tfmodels/repo.txt
+++ b/test/model_level_tests/models/tfmodels/repo.txt
@@ -1,2 +1,2 @@
 https://github.com/tensorflow/models.git
-1c99681ed94495f446399e247a8d63e07f28391c
+v1.13.0

--- a/test/model_level_tests/models/tfmodels1/repo.txt
+++ b/test/model_level_tests/models/tfmodels1/repo.txt
@@ -1,2 +1,2 @@
 https://github.com/tensorflow/models.git
-7b3046768d2d6ea3f306b6ee7b62c02c9ca128a1
+v1.12.0


### PR DESCRIPTION
Use `TensorFlow Models v1.13.0` for `tfmodels` and `TensorFlow v1.12.0` for `tfmodels1`.
Also peg `NGraph models` to `v1.13`.