### PR TITLE
sarkars/Remove event tracing includes

### DIFF
--- a/examples/cpp/inference/inference_engine.cc
+++ b/examples/cpp/inference/inference_engine.cc
@@ -25,7 +25,6 @@
 #include "tensorflow/core/protobuf/rewriter_config.pb.h"
 #include "tensorflow/core/public/session.h"
 
-#include "ngraph/event_tracing.hpp"
 #include "ngraph_bridge/ngraph_backend_manager.h"
 #include "ngraph_bridge/version.h"
 

--- a/ngraph_bridge/ngraph_pipelined_tensors.h
+++ b/ngraph_bridge/ngraph_pipelined_tensors.h
@@ -18,7 +18,6 @@
 #define NGRAPH_TF_BRIDGE_PIPELINED_TENSORS_H_
 #pragma once
 
-#include "ngraph/event_tracing.hpp"
 #include "ngraph/runtime/backend.hpp"
 
 // Consider an ng executable, which has a inputs and b outputs. Let d_input[i]

--- a/ngraph_bridge/ngraph_var.cc
+++ b/ngraph_bridge/ngraph_var.cc
@@ -21,7 +21,6 @@
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/default/logging.h"
 
-#include "ngraph/event_tracing.hpp"
 #include "ngraph/runtime/backend.hpp"
 
 #include "ngraph_bridge/ngraph_backend_manager.h"

--- a/test/test_index_library.cpp
+++ b/test/test_index_library.cpp
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <chrono>
 #include <random>
+#include <thread>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Minor cleanup after https://github.com/tensorflow/ngraph-bridge/pull/475

`test/test_index_library.cpp` originally included `ngraph_bridge/ngraph_pipelined_tensors.h`, which included `ngraph/event_tracing.hpp`, which included `thread`

now that we have removed `ngraph/event_tracing.hpp` from `ngraph_bridge/ngraph_pipelined_tensors.h`, need to include `thread` in `test/test_index_library.cpp`