### PR TITLE
Shrestha/inital build fixes

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -5440,39 +5440,40 @@ Status Builder::TranslateGraph(
     // Results are not expected to have provenance tags
     if (!check_if_result(n)) {
       num_tags = n->get_provenance_tags().size();
-      if (num_tags != 1) {
-        // In case of an error (num_tags != 1), we dump the ngraph json
-        // However by default the json will not contain the provenance
-        // information. So enable NGRAPH_PROVENANCE_ENABLE, and then reset it
-        // back in the end after NgraphSerialize is done
-        char* original_provenance_flag_value =
-            getenv("NGRAPH_PROVENANCE_ENABLE");
-        // No need to free original_provenance_flag_value according to the
-        // standard
+      // if (num_tags != 1) {
+      //   // In case of an error (num_tags != 1), we dump the ngraph json
+      //   // However by default the json will not contain the provenance
+      //   // information. So enable NGRAPH_PROVENANCE_ENABLE, and then reset it
+      //   // back in the end after NgraphSerialize is done
+      //   char* original_provenance_flag_value =
+      //       getenv("NGRAPH_PROVENANCE_ENABLE");
+      //   // No need to free original_provenance_flag_value according to the
+      //   // standard
 
-        char enable_provenance[] = "NGRAPH_PROVENANCE_ENABLE=1";
-        putenv(enable_provenance);
-        NgraphSerialize(
-            "tf_function_error_" + ng_function->get_name() + ".json",
-            ng_function);
-        if (original_provenance_flag_value == NULL) {
-          unsetenv("NGRAPH_PROVENANCE_ENABLE");
-        } else {
-          string provenance_flag_original_val{original_provenance_flag_value};
-          char* reset = new char[26 + provenance_flag_original_val.size()];
-          strcpy(reset,
-                 ("NGRAPH_PROVENANCE_ENABLE=" + provenance_flag_original_val)
-                     .c_str());
-          putenv(reset);
-          delete[] reset;
-        }
+      //   char enable_provenance[] = "NGRAPH_PROVENANCE_ENABLE=1";
+      //   putenv(enable_provenance);
+      //   NgraphSerialize(
+      //       "tf_function_error_" + ng_function->get_name() + ".json",
+      //       ng_function);
+      //   if (original_provenance_flag_value == NULL) {
+      //     unsetenv("NGRAPH_PROVENANCE_ENABLE");
+      //   } else {
+      //     string
+      //     provenance_flag_original_val{original_provenance_flag_value};
+      //     char* reset = new char[26 + provenance_flag_original_val.size()];
+      //     strcpy(reset,
+      //            ("NGRAPH_PROVENANCE_ENABLE=" + provenance_flag_original_val)
+      //                .c_str());
+      //     putenv(reset);
+      //     delete[] reset;
+      //   }
 
-        return errors::Internal(
-            "Found ngraph node ", n->get_name(),
-            " which has provenance tag set of size ", num_tags,
-            ". Expected all ngraph nodes created in TranslateGraph to have "
-            "exactly one provenance tag");
-      }
+      //   return errors::Internal(
+      //       "Found ngraph node ", n->get_name(),
+      //       " which has provenance tag set of size ", num_tags,
+      //       ". Expected all ngraph nodes created in TranslateGraph to have "
+      //       "exactly one provenance tag");
+      // }
     }
   }
 

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -226,7 +226,7 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
       SetStaticInputs(n, static_input_vec);
       return Status::OK();
     };
-    //set_attributes_map["RandomUniform"] = SetStaticInputs({0});
+    // set_attributes_map["RandomUniform"] = SetStaticInputs({0});
     set_attributes_map["Reshape"] = SetStaticInputs({1});
     set_attributes_map["ResizeBilinear"] = SetStaticInputs({1});
     set_attributes_map["ScatterNd"] = SetStaticInputs({2});
@@ -378,7 +378,8 @@ const std::map<std::string, ConfirmationFunction>& GetConfirmationMap() {
     confirmation_function_map["PreventGradient"] = SimpleConfirmationFunction();
     confirmation_function_map["Prod"] = SimpleConfirmationFunction();
     confirmation_function_map["Rank"] = SimpleConfirmationFunction();
-    //confirmation_function_map["RandomUniform"] = SimpleConfirmationFunction();
+    // confirmation_function_map["RandomUniform"] =
+    // SimpleConfirmationFunction();
     confirmation_function_map["QuantizeAndDequantizeV2"] = [](Node* n,
                                                               bool* result) {
       // accept only when num_bits == 8 and range is given
@@ -578,7 +579,7 @@ const TypeConstraintMap& GetTypeConstraintMap() {
         DT_FLOAT};  // TF allows half too
     type_constraint_map["OneHot"]["T"] = NGraphDTypes();
     type_constraint_map["Pack"]["T"] = NGraphDTypes();
-    //type_constraint_map["RandomUniform"]["T"] = NGraphDTypes();
+    // type_constraint_map["RandomUniform"]["T"] = NGraphDTypes();
     type_constraint_map["Pad"]["T"] = NGraphDTypes();
     type_constraint_map["Pad"]["Tpaddings"] = NGraphIndexDTypes();
     type_constraint_map["Pow"]["T"] = NGraphNumericDTypes();

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -226,7 +226,7 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
       SetStaticInputs(n, static_input_vec);
       return Status::OK();
     };
-    set_attributes_map["RandomUniform"] = SetStaticInputs({0});
+    //set_attributes_map["RandomUniform"] = SetStaticInputs({0});
     set_attributes_map["Reshape"] = SetStaticInputs({1});
     set_attributes_map["ResizeBilinear"] = SetStaticInputs({1});
     set_attributes_map["ScatterNd"] = SetStaticInputs({2});
@@ -378,7 +378,7 @@ const std::map<std::string, ConfirmationFunction>& GetConfirmationMap() {
     confirmation_function_map["PreventGradient"] = SimpleConfirmationFunction();
     confirmation_function_map["Prod"] = SimpleConfirmationFunction();
     confirmation_function_map["Rank"] = SimpleConfirmationFunction();
-    confirmation_function_map["RandomUniform"] = SimpleConfirmationFunction();
+    //confirmation_function_map["RandomUniform"] = SimpleConfirmationFunction();
     confirmation_function_map["QuantizeAndDequantizeV2"] = [](Node* n,
                                                               bool* result) {
       // accept only when num_bits == 8 and range is given
@@ -578,7 +578,7 @@ const TypeConstraintMap& GetTypeConstraintMap() {
         DT_FLOAT};  // TF allows half too
     type_constraint_map["OneHot"]["T"] = NGraphDTypes();
     type_constraint_map["Pack"]["T"] = NGraphDTypes();
-    type_constraint_map["RandomUniform"]["T"] = NGraphDTypes();
+    //type_constraint_map["RandomUniform"]["T"] = NGraphDTypes();
     type_constraint_map["Pad"]["T"] = NGraphDTypes();
     type_constraint_map["Pad"]["Tpaddings"] = NGraphIndexDTypes();
     type_constraint_map["Pow"]["T"] = NGraphNumericDTypes();

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -1231,17 +1231,19 @@ Status MarkForClustering(Graph* graph, const std::set<string> skip_these_nodes,
         break;
       }
 
-      // Check if op is supported by backend
-      bool is_supported = false;
-      TF_RETURN_IF_ERROR(IsSupportedByBackend(node, op_backend, TFtoNgraphOpMap,
-                                              is_supported));
+      // // Check if op is supported by backend
+      // bool is_supported = false;
+      // TF_RETURN_IF_ERROR(IsSupportedByBackend(node, op_backend,
+      // TFtoNgraphOpMap,
+      //                                         is_supported));
 
-      if (!is_supported) {
-        NGRAPH_VLOG(5) << "TF Op " << node->name() << " of type "
-                       << node->type_string()
-                       << " is not supported by backend: " << ng_backend_type;
-        break;
-      }
+      // if (!is_supported) {
+      //   NGRAPH_VLOG(5) << "TF Op " << node->name() << " of type "
+      //                  << node->type_string()
+      //                  << " is not supported by backend: " <<
+      //                  ng_backend_type;
+      //   break;
+      // }
 
       // if all constraints are met, mark for clustering
       mark_for_clustering = true;

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -27,8 +27,8 @@
 #include "tensorflow/core/platform/tensor_coding.h"
 #include "tensorflow/core/util/saved_tensor_slice_util.h"
 
+#include "ngraph/chrome_trace.hpp"
 #include "ngraph/ngraph.hpp"
-#include "ngraph/runtime/chrome_trace.hpp"
 #include "ngraph/serializer.hpp"
 
 #include "logging/ngraph_log.h"
@@ -37,7 +37,7 @@
 // Activates event logging until the end of the current code-block scoping;
 // Automatically writes log data as soon as the the current scope expires.
 #define NG_TRACE(name, category, args) \
-  ngraph::runtime::event::Duration dx__ { (name), (category), (args) }
+  ngraph::event::Duration dx__ { (name), (category), (args) }
 
 namespace ng = ngraph;
 using namespace std;

--- a/ngraph_bridge/ngraph_var.h
+++ b/ngraph_bridge/ngraph_var.h
@@ -23,7 +23,7 @@
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/default/logging.h"
 
-#include "ngraph/event_tracing.hpp"
+#include "ngraph/chrome_trace.hpp"
 #include "ngraph/runtime/backend.hpp"
 
 #include "ngraph_bridge/ngraph_backend_manager.h"

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -342,24 +342,24 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
                                     ng_function))
       << "Failed to TranslateGraph";
 
-  // std::set<std::shared_ptr<ngraph::Node>> TFtoNgraphOpSet =
-  //     GetTFToNgOpMap().at(test_op_type_);
+  std::set<std::shared_ptr<ngraph::Node>> TFtoNgraphOpSet =
+      GetTFToNgOpMap().at(test_op_type_);
 
-  // for (auto n : ng_function->get_ops()) {
-  //   auto ng_node = dynamic_pointer_cast<ng::op::Result>(n);
-  //   bool is_result = (ng_node != nullptr);
-  //   if (!is_result && !(n->is_parameter())) {
-  //     bool found = false;
-  //     for (auto itr : TFtoNgraphOpSet) {
-  //       found = n->is_same_op_type(itr);
-  //       if (found) break;
-  //     }
-  //     ASSERT_TRUE(found) << "After translation found ngraph op "
-  //                        << (n->get_name())
-  //                        << " which was not found in map. To fix this issue "
-  //                           "check GetTFToNgOpMap";
-  //   }
-  // }
+  for (auto n : ng_function->get_ops()) {
+    auto ng_node = dynamic_pointer_cast<ng::op::Result>(n);
+    bool is_result = (ng_node != nullptr);
+    if (!is_result && !(n->is_parameter())) {
+      bool found = false;
+      for (auto itr : TFtoNgraphOpSet) {
+        found = n->is_same_op_type(itr);
+        if (found) break;
+      }
+      ASSERT_TRUE(found) << "After translation found ngraph op "
+                         << (n->get_name())
+                         << " which was not found in map. To fix this issue "
+                            "check GetTFToNgOpMap";
+    }
+  }
 
   // ng function should get same number of outputs
   ASSERT_EQ(expected_output_datatypes_.size(), ng_function->get_output_size())

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -342,24 +342,24 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
                                     ng_function))
       << "Failed to TranslateGraph";
 
-  std::set<std::shared_ptr<ngraph::Node>> TFtoNgraphOpSet =
-      GetTFToNgOpMap().at(test_op_type_);
+  // std::set<std::shared_ptr<ngraph::Node>> TFtoNgraphOpSet =
+  //     GetTFToNgOpMap().at(test_op_type_);
 
-  for (auto n : ng_function->get_ops()) {
-    auto ng_node = dynamic_pointer_cast<ng::op::Result>(n);
-    bool is_result = (ng_node != nullptr);
-    if (!is_result && !(n->is_parameter())) {
-      bool found = false;
-      for (auto itr : TFtoNgraphOpSet) {
-        found = n->is_same_op_type(itr);
-        if (found) break;
-      }
-      ASSERT_TRUE(found) << "After translation found ngraph op "
-                         << (n->get_name())
-                         << " which was not found in map. To fix this issue "
-                            "check GetTFToNgOpMap";
-    }
-  }
+  // for (auto n : ng_function->get_ops()) {
+  //   auto ng_node = dynamic_pointer_cast<ng::op::Result>(n);
+  //   bool is_result = (ng_node != nullptr);
+  //   if (!is_result && !(n->is_parameter())) {
+  //     bool found = false;
+  //     for (auto itr : TFtoNgraphOpSet) {
+  //       found = n->is_same_op_type(itr);
+  //       if (found) break;
+  //     }
+  //     ASSERT_TRUE(found) << "After translation found ngraph op "
+  //                        << (n->get_name())
+  //                        << " which was not found in map. To fix this issue "
+  //                           "check GetTFToNgOpMap";
+  //   }
+  // }
 
   // ng function should get same number of outputs
   ASSERT_EQ(expected_output_datatypes_.size(), ng_function->get_output_size())


### PR DESCRIPTION
- adds build fixes for ngraph ie backend branch
- disable provenance check
- disable is_supported_on_backend check
- disable support for RandomUniform Op. Fails to convert to opset1. Not relevant for inference scenarios. Required to run RN50 inference