### PR TITLE
Tweak build_tf.py default config for building with v2.2+

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -386,8 +386,8 @@ def main():
                 os.chdir(pwd)
 
             # Build TensorFlow
-            build_tensorflow(tf_version, venv_dir, "tensorflow",
-                             artifacts_location, target_arch, verbosity)
+            build_tensorflow(tf_version, "tensorflow", artifacts_location,
+                             target_arch, verbosity)
 
             # Now build the libtensorflow_cc.so - the C++ library
             build_tensorflow_cc(tf_version, tf_src_dir, artifacts_location,

--- a/build_tf.py
+++ b/build_tf.py
@@ -67,7 +67,7 @@ def main():
         os.chdir(pwd)
 
     # Build TensorFlow
-    build_tensorflow(arguments.tf_version, venv_dir, "tensorflow", 'artifacts',
+    build_tensorflow(arguments.tf_version, "tensorflow", 'artifacts',
                      arguments.target_arch, False)
 
     # Build TensorFlow C++ Library

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -229,7 +229,7 @@ def build_tensorflow(tf_version,
         ])
 
     # If target is not specified, we assume default TF wheel build
-    if target != '':
+    if target == '':
         target = "//tensorflow/tools/pip_package:build_pip_package"
 
     cmd.extend([target])
@@ -240,7 +240,7 @@ def build_tensorflow(tf_version,
     command_executor(cmd)
 
     # If target is not specified, we assume default TF wheel build and copy the wheel to artifacts dir
-    if target != '':
+    if target == '':
         command_executor([
             "bazel-bin/tensorflow/tools/pip_package/build_pip_package",
             artifacts_dir

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -149,6 +149,7 @@ def setup_venv(venv_dir):
         "install",
         "-U",
         "pip",
+        "psutil",
         "six>=1.10.0",
         "numpy>=1.13.3",
         "wheel>=0.26",

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -240,7 +240,7 @@ def build_tensorflow(tf_version,
     command_executor(cmd)
 
     # If target is not specified, we assume default TF wheel build and copy the wheel to artifacts dir
-    if target == '':
+    if target == '//tensorflow/tools/pip_package:build_pip_package':
         command_executor([
             "bazel-bin/tensorflow/tools/pip_package/build_pip_package",
             artifacts_dir

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -148,23 +148,17 @@ def setup_venv(venv_dir):
         "pip",
         "install",
         "-U",
-        "pip==19.3.1",
-        "setuptools",
-        "psutil",
+        "pip",
         "six>=1.10.0",
         "numpy>=1.13.3",
-        "absl-py>=0.1.6",
-        "astor>=0.6.0",
-        "google_pasta>=0.1.1",
         "wheel>=0.26",
+        "setuptools",
         "mock",
         "termcolor>=1.1.0",
-        "protobuf>=3.6.1",
         "keras_applications>=1.0.6",
         "--no-deps",
         "keras_preprocessing==1.0.5",
         "--no-deps",
-        "yapf==0.26.0",
     ]
     command_executor(package_list)
 
@@ -172,16 +166,12 @@ def setup_venv(venv_dir):
     command_executor(["pip", "list"])
 
 
-def build_tensorflow(tf_version, venv_dir, src_dir, artifacts_dir, target_arch,
-                     verbosity):
-
-    base = sys.prefix
-    python_lib_path = os.path.join(base, 'lib', 'python%s' % sys.version[:3],
-                                   'site-packages')
-    python_executable = os.path.join(base, "bin", "python")
-
-    print("PYTHON_BIN_PATH: " + python_executable)
-
+def build_tensorflow(tf_version,
+                     src_dir,
+                     artifacts_dir,
+                     target_arch,
+                     verbosity,
+                     target=""):
     # In order to build TensorFlow, we need to be in the virtual environment
     pwd = os.getcwd()
 
@@ -194,23 +184,28 @@ def build_tensorflow(tf_version, venv_dir, src_dir, artifacts_dir, target_arch,
 
     os.chdir(src_dir)
 
+    base = sys.prefix
+    python_lib_path = os.path.join(base, 'lib', 'python%s' % sys.version[:3],
+                                   'site-packages')
+    python_executable = os.path.join(base, "bin", "python")
+
+    print("PYTHON_BIN_PATH: " + python_executable)
+
     # Set the TensorFlow configuration related variables
     os.environ["PYTHON_BIN_PATH"] = python_executable
     os.environ["PYTHON_LIB_PATH"] = python_lib_path
-    os.environ["TF_NEED_IGNITE"] = "0"
+    os.environ["TF_NEED_XLA"] = "0"
     if (platform.system() == 'Darwin'):
-        os.environ["TF_ENABLE_XLA"] = "0"
         os.environ["TF_CONFIGURE_IOS"] = "0"
-    else:
-        os.environ["TF_ENABLE_XLA"] = "1"
     os.environ["TF_NEED_OPENCL_SYCL"] = "0"
     os.environ["TF_NEED_COMPUTECPP"] = "0"
     os.environ["TF_NEED_ROCM"] = "0"
     os.environ["TF_NEED_MPI"] = "0"
     os.environ["TF_NEED_CUDA"] = "0"
+    os.environ["TF_NEED_TENSORRT"] = "0"
     os.environ["TF_DOWNLOAD_CLANG"] = "0"
     os.environ["TF_SET_ANDROID_WORKSPACE"] = "0"
-    os.environ["CC_OPT_FLAGS"] = "-march=" + target_arch
+    os.environ["CC_OPT_FLAGS"] = "-march=" + target_arch + " -Wno-sign-compare"
 
     command_executor("./configure")
 
@@ -223,47 +218,64 @@ def build_tensorflow(tf_version, venv_dir, src_dir, artifacts_dir, target_arch,
         "--config=nonccl",
     ]
     # Build the python package
-    if (tf_version.startswith("v2.")):
+    if (tf_version.startswith("v2.") or tf_version.startswith("2.")):
         cmd.extend([
             "--config=v2",
         ])
-    elif (tf_version.startswith("v1.")):
+    elif (tf_version.startswith("v1.") or tf_version.startswith("1.")):
         cmd.extend([
             "--config=v1",
         ])
-    cmd.extend([
-        "//tensorflow/tools/pip_package:build_pip_package",
-    ])
+
+    # If target is not specified, we assume default TF wheel build
+    if target != '':
+        target = "//tensorflow/tools/pip_package:build_pip_package"
+
+    cmd.extend([target])
 
     if verbosity:
         cmd.extend(['-s'])
 
     command_executor(cmd)
 
-    command_executor([
-        "bazel-bin/tensorflow/tools/pip_package/build_pip_package",
-        artifacts_dir
-    ])
+    # If target is not specified, we assume default TF wheel build and copy the wheel to artifacts dir
+    if target != '':
+        command_executor([
+            "bazel-bin/tensorflow/tools/pip_package/build_pip_package",
+            artifacts_dir
+        ])
 
-    # Get the name of the TensorFlow pip package
-    tf_wheel_files = glob.glob(os.path.join(artifacts_dir, "tensorflow-*.whl"))
-    print("TF Wheel: %s" % tf_wheel_files[0])
+        # Get the name of the TensorFlow pip package
+        tf_wheel_files = glob.glob(
+            os.path.join(artifacts_dir, "tensorflow-*.whl"))
+        print("TF Wheel: %s" % tf_wheel_files[0])
 
     # popd
     os.chdir(pwd)
 
 
-def build_tensorflow_cc(tf_version, src_dir, artifacts_dir, target_arch,
-                        verbosity):
+def build_tensorflow_cc(tf_version,
+                        src_dir,
+                        artifacts_dir,
+                        target_arch,
+                        verbosity,
+                        tf_prebuilt=None):
+    lib = "libtensorflow_cc.so.2"
+    if (tf_version.startswith("v2.") or tf_version.startswith("2.")):
+        tf_cc_lib_name = "libtensorflow_cc.so.2"
+    elif (tf_version.startswith("v1.") or tf_version.startswith("1.")):
+        tf_cc_lib_name = "libtensorflow_cc.so.1"
 
+    build_tensorflow(
+        tf_version,
+        src_dir,
+        artifacts_dir,
+        target_arch,
+        verbosity,
+        target="//tensorflow:" + tf_cc_lib_name)
+
+    # In order to build TensorFlow, we need to be in the virtual environment
     pwd = os.getcwd()
-
-    base = sys.prefix
-    python_lib_path = os.path.join(base, 'lib', 'python%s' % sys.version[:3],
-                                   'site-packages')
-    python_executable = os.path.join(base, "bin", "python")
-
-    print("PYTHON_BIN_PATH: " + python_executable)
 
     src_dir = os.path.abspath(src_dir)
     print("SOURCE DIR: " + src_dir)
@@ -273,58 +285,6 @@ def build_tensorflow_cc(tf_version, src_dir, artifacts_dir, target_arch,
     print("ARTIFACTS DIR: %s" % artifacts_dir)
 
     os.chdir(src_dir)
-
-    # Set the TensorFlow configuration related variables
-    os.environ["PYTHON_BIN_PATH"] = python_executable
-    os.environ["PYTHON_LIB_PATH"] = python_lib_path
-    os.environ["TF_NEED_IGNITE"] = "0"
-    if (platform.system() == 'Darwin'):
-        os.environ["TF_ENABLE_XLA"] = "0"
-        os.environ["TF_CONFIGURE_IOS"] = "0"
-    else:
-        os.environ["TF_ENABLE_XLA"] = "1"
-    os.environ["TF_NEED_OPENCL_SYCL"] = "0"
-    os.environ["TF_NEED_COMPUTECPP"] = "0"
-    os.environ["TF_NEED_ROCM"] = "0"
-    os.environ["TF_NEED_MPI"] = "0"
-    os.environ["TF_NEED_CUDA"] = "0"
-    os.environ["TF_DOWNLOAD_CLANG"] = "0"
-    os.environ["TF_SET_ANDROID_WORKSPACE"] = "0"
-    os.environ["CC_OPT_FLAGS"] = "-march=" + target_arch
-
-    command_executor("./configure")
-
-    # Now build the TensorFlow C++ library
-    cmd = [
-        "bazel",
-        "build",
-        "--config=opt",
-        "--config=noaws",
-        "--config=nohdfs",
-        "--config=noignite",
-        "--config=nokafka",
-        "--config=nonccl",
-    ]
-    # Build the python package
-    if (tf_version.startswith("v2.")):
-        cmd.extend(["--config=v2", "//tensorflow:libtensorflow_cc.so.2"])
-    elif (tf_version.startswith("v1.")):
-        cmd.extend(["--config=v1", "//tensorflow:libtensorflow_cc.so.1"])
-
-    command_executor(cmd)
-    copy_tf_cc_lib_to_artifacts(tf_version, artifacts_dir, None)
-
-    # popd
-    os.chdir(pwd)
-
-
-def copy_tf_cc_lib_to_artifacts(tf_version, artifacts_dir, tf_prebuilt):
-    if (tf_version.startswith("v2.")):
-        tf_cc_lib_name = 'libtensorflow_cc.so.2'
-    elif (tf_version.startswith("v1.")):
-        tf_cc_lib_name = 'libtensorflow_cc.so.1'
-    #if (platform.system() == 'Darwin'):
-    #tf_cc_lib_name = 'libtensorflow_cc.1.dylib'
     try:
         doomed_file = os.path.join(artifacts_dir, tf_cc_lib_name)
         os.unlink(doomed_file)
@@ -340,6 +300,7 @@ def copy_tf_cc_lib_to_artifacts(tf_version, artifacts_dir, tf_prebuilt):
 
     print("Copying %s to %s" % (tf_cc_lib_file, artifacts_dir))
     shutil.copy(tf_cc_lib_file, artifacts_dir)
+    os.chdir(pwd)
 
 
 def locate_tf_whl(tf_whl_loc):

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -150,15 +150,15 @@ def setup_venv(venv_dir):
         "-U",
         "pip",
         "psutil",
-        "six>=1.10.0",
-        "numpy>=1.13.3",
+        "six>=1.12.0",
+        "numpy>=1.16.0,<1.19.0",
         "wheel>=0.26",
         "setuptools",
         "mock",
         "termcolor>=1.1.0",
         "keras_applications>=1.0.6",
         "--no-deps",
-        "keras_preprocessing==1.0.5",
+        "keras_preprocessing>=1.1.1,<1.2",
         "--no-deps",
     ]
     command_executor(package_list)
@@ -195,7 +195,7 @@ def build_tensorflow(tf_version,
     # Set the TensorFlow configuration related variables
     os.environ["PYTHON_BIN_PATH"] = python_executable
     os.environ["PYTHON_LIB_PATH"] = python_lib_path
-    os.environ["TF_NEED_XLA"] = "0"
+    os.environ["TF_ENABLE_XLA"] = "0"
     if (platform.system() == 'Darwin'):
         os.environ["TF_CONFIGURE_IOS"] = "0"
     os.environ["TF_NEED_OPENCL_SYCL"] = "0"


### PR DESCRIPTION
* Fix pip numpy dependency to v1.18.5
* Tweak default TF build config to add "--config=nogcp", "TF_NEED_TENSORRT=0",
etc. to match the default config
* Refactor TF build helpers to remove duplication