### PR TITLE
Skip python model tester test

### DIFF
--- a/test/python/test_modeltester.py
+++ b/test/python/test_modeltester.py
@@ -32,6 +32,7 @@ import ngraph_bridge
 
 class TestModelTester(NgraphTest):
 
+    @pytest.mark.skip(reason="Disabling until bridge is more stable")
     @pytest.mark.skipif(platform.system() == 'Darwin', reason='Only for Linux')
     def test_MLP(self):
         cwd = os.getcwd()


### PR DESCRIPTION
Skipping the python model tester test for the time being until we have all the changes in place.