### PR TITLE
Dump IE graphs when NGRAPH_TF_DUMP_GRAPHS is set

### DIFF
--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -44,6 +44,11 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
   m_network = InferenceEngine::CNNNetwork(func);
   set_parameters_and_results(*func);
 
+  if (std::getenv("NGRAPH_TF_DUMP_GRAPHS")) {
+    auto& name = m_network.getName();
+    m_network.serialize(name + ".xml", name + ".bin");
+  }
+
   NGRAPH_VLOG(2) << "Loading IE CNN network to device " << m_device;
 
   InferenceEngine::Core ie;

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -94,17 +94,12 @@ Status NGraphEncapsulateImpl::Compile(
   BackendManager::LockBackend(backend_name);
   try {
     ng_exec = op_backend->compile(ng_function);
-  } catch (...) {
+  } catch (const std::exception& ex) {
     BackendManager::UnlockBackend(backend_name);
     string fn_name = ng_function->get_friendly_name();
-    Status st =
-        NgraphSerialize("tf_function_" + fn_name + ".json", ng_function);
+    NgraphSerialize("tf_function_" + fn_name + ".json", ng_function);
     BackendManager::ReleaseBackend(backend_name);
-    return errors::Internal(
-        "Failed to compile ng_function.",
-        (st.ok() ? ""
-                 : " Failed to serialize as well with error: " +
-                       st.error_message()));
+    return errors::Internal("Failed to compile ng_function: ", ex.what());
   }
   BackendManager::UnlockBackend(backend_name);
   return Status::OK();


### PR DESCRIPTION
* Dump IE CNN network and weights when NGRAPH_TF_DUMP_GRAPHS is set
* Make sure IE exceptions are caught in case of compilation errors