### PR TITLE
Support allocation of IE tensors without external memory

### DIFF
--- a/ngraph_bridge/ie_tensor.h
+++ b/ngraph_bridge/ie_tensor.h
@@ -30,6 +30,7 @@ class IETensor : public ngraph::runtime::Tensor {
            const ngraph::PartialShape& shape);
   IETensor(const ngraph::element::Type& element_type,
            const ngraph::Shape& shape, void* memory_pointer);
+  ~IETensor() override;
 
   void write(const void* src, size_t bytes) override;
   void read(void* dst, size_t bytes) const override;


### PR DESCRIPTION
IE Blob API does not handle the case where the passed in external memory pointer is a nullptr and/or the specified size argument is 0. We fix this issue by checking if the supplied pointer is nullptr and create a Blob without any external memory argument specified.