### PR TITLE
(dontmerge) enable OPV IE C++ unit tests (part 1)

### DIFF
--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -71,9 +71,9 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
   //DBG_ONLY: 
   // Example: Result_353->Constant_673, Result_350->ngraph_output_1, ...
   //DBG_ONLY: std::cout << "\n*** m_results " << m_results.size() << " ==> "; for (auto& op : m_results) { std::cout << op->get_name() << ", "; } std::cout << "\n";
-  std::cout << "\n*** m_map_result_to_ngnode " << m_map_result_to_ngnode.size() << " ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  //std::cout << "\n*** m_map_result_to_ngnode " << m_map_result_to_ngnode.size() << " ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
   //DBG_ONLY: 
-  std::cout << "\n*** m_nongraph_const_outputs " << m_nongraph_const_outputs.size() << " ==> "; for (auto const& pair : m_nongraph_const_outputs) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  //std::cout << "\n*** m_nongraph_const_outputs " << m_nongraph_const_outputs.size() << " ==> "; for (auto const& pair : m_nongraph_const_outputs) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
   // Example: Constant_673->Result_353,  ngraph_output_1->Result_350, ...
 
   NGRAPH_CHECK(m_results.size()==m_map_result_to_ngnode.size(), "Mismatching number of result/output items");
@@ -148,8 +148,8 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
       }
   }
   //DBG_ONLY: 
-  std::cout << "\nIE_Executable ctor, m_map_cnnparam_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
-  //NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(), "Mismatching number of param/input items for orig-func and m_network.getFunction()");
+  //std::cout << "\nIE_Executable ctor, m_map_cnnparam_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  ////Dont' check NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(), "Mismatching number of param/input items for orig-func and m_network.getFunction()");
 
 #if 1
   // Bani
@@ -175,7 +175,7 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
       idx++;
   }
   //DBG_ONLY: 
-  std::cout << "\nIE_Executable ctor, m_map_cnnresult_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnresult_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  //std::cout << "\nIE_Executable ctor, m_map_cnnresult_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnresult_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
 #endif
 
   NGRAPH_VLOG(2) << "Loading IE CNN network to device=" << m_device << ", ng-function=" << m_network.getFunction()->get_friendly_name();

--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -28,7 +28,6 @@ using namespace ngraph;
 namespace tensorflow {
 namespace ngraph_bridge {
 
-
 IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
     : m_device{device} {
   NGRAPH_VLOG(2) << "Checking for unsupported ops in IE backend";
@@ -51,7 +50,8 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
 
   NGRAPH_VLOG(2) << "Creating IE CNN network using nGraph function";
   m_network = InferenceEngine::CNNNetwork(func2);
-  //// CAUTION: set_parameters_and_results(*func2); // Don't update again, as we want TF to pass us all inputs & outputs tensors per the original func
+  //// CAUTION: set_parameters_and_results(*func2); // Don't update again, as we
+  ///want TF to pass us all inputs & outputs tensors per the original func
 
   if (std::getenv("NGRAPH_TF_DUMP_GRAPHS")) {
     auto& name = m_network.getName();
@@ -60,50 +60,67 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
 
   InfoSaveInOutIndexMaps();
 
-  NGRAPH_VLOG(2) << "Loading IE CNN network to device=" << m_device << ", ng-function=" << m_network.getFunction()->get_friendly_name();
+  NGRAPH_VLOG(2) << "Loading IE CNN network to device=" << m_device
+                 << ", ng-function="
+                 << m_network.getFunction()->get_friendly_name();
   InferenceEngine::Core ie;
   // Load model to the plugin (m_device)
   InferenceEngine::ExecutableNetwork exe_network =
       ie.LoadNetwork(m_network, m_device);
 
   // Create infer request
-  NGRAPH_VLOG(5) << "IE_Executable calling CreateInferRequest() --> " << m_network.getFunction()->get_friendly_name();
+  NGRAPH_VLOG(5) << "IE_Executable calling CreateInferRequest() --> "
+                 << m_network.getFunction()->get_friendly_name();
   m_infer_req = exe_network.CreateInferRequest();
 }
 
 bool IE_Executable::call(const vector<shared_ptr<runtime::Tensor>>& outputs,
                          const vector<shared_ptr<runtime::Tensor>>& inputs) {
-  NGRAPH_VLOG(5) << "IE_Executable::call BEGIN --> " << m_network.getFunction()->get_friendly_name();
-  
+  NGRAPH_VLOG(5) << "IE_Executable::call BEGIN --> "
+                 << m_network.getFunction()->get_friendly_name();
+
   // A note about input and output tensor orders:
-  // Example from ng func (the param vectors are in this order for outputs and inputs respectively):
-  //   outs(10) = Add_359(*), Constant_673, Constant_675, ngraph_output_0(*), ngraph_output_1, ngraph_output_2, ngraph_output_6, ngraph_output_7, ngraph_output_8, ngraph_output_9,
-  //     The ones with * are actual dynamic computed results/outs from the IE/CNN
+  // Example from ng func (the param vectors are in this order for outputs and
+  // inputs respectively):
+  //   outs(10) = Add_359(*), Constant_673, Constant_675, ngraph_output_0(*),
+  //   ngraph_output_1, ngraph_output_2, ngraph_output_6, ngraph_output_7,
+  //   ngraph_output_8, ngraph_output_9,
+  //     The ones with * are actual dynamic computed results/outs from the
+  //     IE/CNN
   //   ins(2) = _arg_import/best_practices_0_0, _arg_import/read_tensor_0_1,
-  // Example Const to ng result map (m_nongraph_const_outputs), helpful for tensor data copying:
-  //   Constant_673->Result_353, Constant_675->Result_352, ngraph_output_1->Result_350, ngraph_output_2->Result_351, 
-  //   ngraph_output_6->Result_355, ngraph_output_7->Result_356, ngraph_output_8->Result_357, ngraph_output_9->Result_358,
+  // Example Const to ng result map (m_nongraph_const_outputs), helpful for
+  // tensor data copying:
+  //   Constant_673->Result_353, Constant_675->Result_352,
+  //   ngraph_output_1->Result_350, ngraph_output_2->Result_351,
+  //   ngraph_output_6->Result_355, ngraph_output_7->Result_356,
+  //   ngraph_output_8->Result_357, ngraph_output_9->Result_358,
 
   InferenceEngine::InputsDataMap input_info = m_network.getInputsInfo();
   if (m_params_orig.size() != inputs.size()) {
     THROW_IE_EXCEPTION
         << "Ng-Function inputs number differ from number of given inputs";
   }
-  
+
   // Align input tensor index with IE-CNN's param index
   size_t i = 0;
   for (const auto& it : input_info) {
     auto input_name = it.first;
     // Check which TF-tensor-input# this input_name matches with
-    if(m_map_cnnparam_to_tfidx.find(input_name) == m_map_cnnparam_to_tfidx.end()) {
-        THROW_IE_EXCEPTION << "\n!!! Cannot locate in m_map_cnnparam_to_tfidx, input/param = " << input_name << " !!!\n";
+    if (m_map_cnnparam_to_tfidx.find(input_name) ==
+        m_map_cnnparam_to_tfidx.end()) {
+      THROW_IE_EXCEPTION
+          << "\n!!! Cannot locate in m_map_cnnparam_to_tfidx, input/param = "
+          << input_name << " !!!\n";
     }
     int idx_tensor_input = m_map_cnnparam_to_tfidx.at(input_name);
-    if(idx_tensor_input >= inputs.size()) {
-        THROW_IE_EXCEPTION << "\n!!! Bad idx_tensor_input for " << input_name << ", idx_tensor_input = " << idx_tensor_input << " !!!\n";
+    if (idx_tensor_input >= inputs.size()) {
+      THROW_IE_EXCEPTION << "\n!!! Bad idx_tensor_input for " << input_name
+                         << ", idx_tensor_input = " << idx_tensor_input
+                         << " !!!\n";
     }
 
-    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(inputs[idx_tensor_input]);
+    shared_ptr<IETensor> tv =
+        static_pointer_cast<IETensor>(inputs[idx_tensor_input]);
     m_infer_req.SetBlob(input_name, tv->get_blob());
     i++;
   }
@@ -114,113 +131,165 @@ bool IE_Executable::call(const vector<shared_ptr<runtime::Tensor>>& outputs,
     THROW_IE_EXCEPTION
         << "Function outputs number differ from number of given outputs";
   }
-  NGRAPH_CHECK(m_results_orig.size()==outputs.size(), "Mismatching number of output items between tensors (", outputs.size(), ") and results (", m_results_orig.size() ,")");
+  NGRAPH_CHECK(m_results_orig.size() == outputs.size(),
+               "Mismatching number of output items between tensors (",
+               outputs.size(), ") and results (", m_results_orig.size(), ")");
 
   // Shortcut the Const -> Result values
-  for(const auto& it : m_map_cnnconstresult_to_ngnodeptr) {
-      auto output_name = it.first;
-      const ngraph::op::Constant* const_node = (ngraph::op::Constant*)(it.second);
-      if(const_node) {
-          int idx_tensor_output = m_map_cnnresult_to_tfidx.at(output_name);
-          auto num_bytes = shape_size(const_node->get_shape()) * const_node->get_element_type().size();
-          //DBG_ONLY: 
-          std::cout << "    ... shortcut value from Const node " << output_name << " to TF Output " << m_nongraph_const_outputs.at(output_name) << ", index=" << ", num_bytes=" << num_bytes << "\n";
-          const void* value = const_node->get_data_ptr();
-          outputs[idx_tensor_output]->write(value, num_bytes);
-      } else {
-          THROW_IE_EXCEPTION << "\n!!! Cannot get const_node = " << output_name << " for value shortcut !!!\n";
-      }
+  for (const auto& it : m_map_cnnconstresult_to_ngnodeptr) {
+    auto output_name = it.first;
+    const ngraph::op::Constant* const_node = (ngraph::op::Constant*)(it.second);
+    if (const_node) {
+      int idx_tensor_output = m_map_cnnresult_to_tfidx.at(output_name);
+      auto num_bytes = shape_size(const_node->get_shape()) *
+                       const_node->get_element_type().size();
+      // DBG_ONLY:
+      std::cout << "    ... shortcut value from Const node " << output_name
+                << " to TF Output " << m_nongraph_const_outputs.at(output_name)
+                << ", index="
+                << ", num_bytes=" << num_bytes << "\n";
+      const void* value = const_node->get_data_ptr();
+      outputs[idx_tensor_output]->write(value, num_bytes);
+    } else {
+      THROW_IE_EXCEPTION << "\n!!! Cannot get const_node = " << output_name
+                         << " for value shortcut !!!\n";
+    }
   }
 
   // Pass the other output tensors
   for (const auto& it : output_info) {
     auto output_name = it.first;
-    NGRAPH_CHECK(m_map_cnnresult_to_tfidx.count(output_name) == 1, "!!! Output ", output_name, " not found !!!");
+    NGRAPH_CHECK(m_map_cnnresult_to_tfidx.count(output_name) == 1,
+                 "!!! Output ", output_name, " not found !!!");
     int idx_tensor_output = m_map_cnnresult_to_tfidx.at(output_name);
 
-    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(outputs[idx_tensor_output]);
-    //DBG_ONLY: 
-    NGRAPH_VLOG(5) << "func => " << m_network.getFunction()->get_friendly_name() <<
-    " Calling m_infer_req.SetBlob for output " << output_name << ", count=" << tv->get_element_count() << 
-    ", network precision=" << it.second->getTensorDesc().getPrecision().name() << 
-    ", tensor type=" << tv->get_element_type().get_type_name() << "\n";
+    shared_ptr<IETensor> tv =
+        static_pointer_cast<IETensor>(outputs[idx_tensor_output]);
+    // DBG_ONLY:
+    NGRAPH_VLOG(5) << "func => " << m_network.getFunction()->get_friendly_name()
+                   << " Calling m_infer_req.SetBlob for output " << output_name
+                   << ", count=" << tv->get_element_count()
+                   << ", network precision="
+                   << it.second->getTensorDesc().getPrecision().name()
+                   << ", tensor type=" << tv->get_element_type().get_type_name()
+                   << "\n";
 
     m_infer_req.SetBlob(output_name, tv->get_blob());
   }
 
-  NGRAPH_VLOG(5) << "IE_Executable::call -> m_infer_req.Infer() --> " << m_network.getFunction()->get_friendly_name();
+  NGRAPH_VLOG(5) << "IE_Executable::call -> m_infer_req.Infer() --> "
+                 << m_network.getFunction()->get_friendly_name();
   m_infer_req.Infer();
   return true;
-} // end of call()
-
+}  // end of call()
 
 void IE_Executable::InfoSaveResultMaps() {
-  // We need to save the mapping from CNN network's Result nodes to the original NG-function's result-contributing nodes
-  // m_map_result_to_ngnode e.g. (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+  // We need to save the mapping from CNN network's Result nodes to the original
+  // NG-function's result-contributing nodes
+  // m_map_result_to_ngnode e.g. (result, from) e.g. Result_353->Constant_673,
+  // Result_350->ngraph_output_1
   // Also...
-  // OPV/IE CNN doesn't handle Constant nodes that are directly connected to an Output/Result node, save in m_nongraph_const_outputs
-  // (input-const, output-result) e.g. Constant_675->Result_352, ngraph_output_1->Result_350
-  for (const auto& ng_result_node : m_results) { // Note: order of m_results matches with ngfunc's outputs' order, and TF-output-tensors
-      const auto& ng_result_name = ng_result_node->get_name(); // Result_353 or Result_350
-      // Find within the related NGFUNC, the parent/contributing node which feeds to this cnn_result_name
-      const auto& cnn_result_node = ng_result_node->input(0).get_source_output().get_node();
-      const auto& cnn_result_name = cnn_result_node->get_friendly_name(); //  e.g. Constant_675 or ngraph_output_1 // Don't use get_name()!!
-      //DBG_ONLY: std::cout << " IE_Executable cnn --> ng_result : " << cnn_result_name << " --> " << ng_result_name << "\n";
-      m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(ng_result_name, cnn_result_name));
-      if(cnn_result_node->is_constant()) {
-          // (input-const, output-result) e.g. Constant_675->Result_352, ngraph_output_1->Result_350
-          m_nongraph_const_outputs.insert(std::pair<std::string, std::string>(cnn_result_name, ng_result_name));
-          const ngraph::op::Constant* const_node = dynamic_cast<const ngraph::op::Constant*>(&(*cnn_result_node));
-          if(const_node) {
-              m_map_cnnconstresult_to_ngnodeptr.insert(std::pair<std::string, void*>(cnn_result_name, (void*)const_node));
-          } else {
-              THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast<const ngraph::op::Constant*>, const-node = " << cnn_result_name << " !!!\n";
-          }
+  // OPV/IE CNN doesn't handle Constant nodes that are directly connected to an
+  // Output/Result node, save in m_nongraph_const_outputs
+  // (input-const, output-result) e.g. Constant_675->Result_352,
+  // ngraph_output_1->Result_350
+  for (const auto& ng_result_node :
+       m_results) {  // Note: order of m_results matches with ngfunc's outputs'
+                     // order, and TF-output-tensors
+    const auto& ng_result_name =
+        ng_result_node->get_name();  // Result_353 or Result_350
+    // Find within the related NGFUNC, the parent/contributing node which feeds
+    // to this cnn_result_name
+    const auto& cnn_result_node =
+        ng_result_node->input(0).get_source_output().get_node();
+    const auto& cnn_result_name =
+        cnn_result_node->get_friendly_name();  //  e.g. Constant_675 or
+                                               //  ngraph_output_1 // Don't use
+                                               //  get_name()!!
+    // DBG_ONLY: std::cout << " IE_Executable cnn --> ng_result : " <<
+    // cnn_result_name << " --> " << ng_result_name << "\n";
+    m_map_result_to_ngnode.insert(
+        std::pair<std::string, std::string>(ng_result_name, cnn_result_name));
+    if (cnn_result_node->is_constant()) {
+      // (input-const, output-result) e.g. Constant_675->Result_352,
+      // ngraph_output_1->Result_350
+      m_nongraph_const_outputs.insert(
+          std::pair<std::string, std::string>(cnn_result_name, ng_result_name));
+      const ngraph::op::Constant* const_node =
+          dynamic_cast<const ngraph::op::Constant*>(&(*cnn_result_node));
+      if (const_node) {
+        m_map_cnnconstresult_to_ngnodeptr.insert(
+            std::pair<std::string, void*>(cnn_result_name, (void*)const_node));
+      } else {
+        THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast<const "
+                              "ngraph::op::Constant*>, const-node = "
+                           << cnn_result_name << " !!!\n";
       }
+    }
   }
-  //DBG_ONLY: 
+  // DBG_ONLY:
   // Example: Result_353->Constant_673, Result_350->ngraph_output_1, ...
-  //DBG_ONLY: std::cout << "\n*** m_results " << m_results.size() << " ==> "; for (auto& op : m_results) { std::cout << op->get_name() << ", "; } std::cout << "\n";
-  //std::cout << "\n*** m_map_result_to_ngnode " << m_map_result_to_ngnode.size() << " ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
-  //DBG_ONLY: 
-  //std::cout << "\n*** m_nongraph_const_outputs " << m_nongraph_const_outputs.size() << " ==> "; for (auto const& pair : m_nongraph_const_outputs) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  // DBG_ONLY: std::cout << "\n*** m_results " << m_results.size() << " ==> ";
+  // for (auto& op : m_results) { std::cout << op->get_name() << ", "; }
+  // std::cout << "\n";
+  // std::cout << "\n*** m_map_result_to_ngnode " <<
+  // m_map_result_to_ngnode.size() << " ==> "; for (auto const& pair :
+  // m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second <<
+  // ", "; } std::cout << "\n";
+  // DBG_ONLY:
+  // std::cout << "\n*** m_nongraph_const_outputs " <<
+  // m_nongraph_const_outputs.size() << " ==> "; for (auto const& pair :
+  // m_nongraph_const_outputs) { std::cout << pair.first << "->" << pair.second
+  // << ", "; } std::cout << "\n";
   // Example: Constant_673->Result_353,  ngraph_output_1->Result_350, ...
 
-  NGRAPH_CHECK(m_results.size()==m_map_result_to_ngnode.size(), "Mismatching number of result/output items");
+  NGRAPH_CHECK(m_results.size() == m_map_result_to_ngnode.size(),
+               "Mismatching number of result/output items");
   for (auto& op : m_results) {
-      if(m_map_result_to_ngnode.count(op->get_name()) == 0) {
-          std::cout << "m_results ==> "; for (auto& op2 : m_results) { std::cout << op2->get_name() << ", "; } std::cout << "\n";
-          THROW_IE_EXCEPTION << "\n!!! m_results op " << op->get_name() << " not found in m_map_result_to_ngnode !!!\n";
+    if (m_map_result_to_ngnode.count(op->get_name()) == 0) {
+      std::cout << "m_results ==> ";
+      for (auto& op2 : m_results) {
+        std::cout << op2->get_name() << ", ";
       }
+      std::cout << "\n";
+      THROW_IE_EXCEPTION << "\n!!! m_results op " << op->get_name()
+                         << " not found in m_map_result_to_ngnode !!!\n";
+    }
   }
 }
 
-shared_ptr<Function> IE_Executable::StripOffUnhandledNodes(const shared_ptr<Function> &func) {
+shared_ptr<Function> IE_Executable::StripOffUnhandledNodes(
+    const shared_ptr<Function>& func) {
   shared_ptr<Function> func2 = func;
 
   // Let's don't send disconnected Const -> Result nodes to IE
-  if(m_nongraph_const_outputs.size() > 0) {
-    vector<shared_ptr<ngraph::Node>> ng_result_list2; // (func->get_results().size() - m_nongraph_const_outputs.size());
+  if (m_nongraph_const_outputs.size() > 0) {
+    vector<shared_ptr<ngraph::Node>>
+        ng_result_list2;  // (func->get_results().size() -
+                          // m_nongraph_const_outputs.size());
     for (auto& opresult : func->get_results()) {
-        const auto& ng_result_name = opresult->get_name();
-        if(m_map_result_to_ngnode.count(ng_result_name) == 1) {
-            const auto& cnn_result_name = m_map_result_to_ngnode.at(ng_result_name);
-            if(m_nongraph_const_outputs.count(cnn_result_name) == 1) {
-                continue;
-            }
+      const auto& ng_result_name = opresult->get_name();
+      if (m_map_result_to_ngnode.count(ng_result_name) == 1) {
+        const auto& cnn_result_name = m_map_result_to_ngnode.at(ng_result_name);
+        if (m_nongraph_const_outputs.count(cnn_result_name) == 1) {
+          continue;
         }
-        ng_result_list2.push_back(opresult);
+      }
+      ng_result_list2.push_back(opresult);
     }
-    func2 = make_shared<ngraph::Function>(ng_result_list2, func->get_parameters());
+    func2 =
+        make_shared<ngraph::Function>(ng_result_list2, func->get_parameters());
     func2->set_friendly_name(func->get_friendly_name());
   }
 
   // after above
   // Let's strip off any isolated Param nodes
   ngraph::ParameterVector ng_param_list2;
-  for (auto& node : func2->get_parameters()) { // node is a shared_ptr of Node
-    if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
-      NGRAPH_VLOG(5) << "!! Stripping off isolated Param node: " << node->get_friendly_name();
+  for (auto& node : func2->get_parameters()) {  // node is a shared_ptr of Node
+    if (node->get_output_size() > 0 &&
+        node->output(0).get_target_inputs().size() == 0) {
+      NGRAPH_VLOG(5) << "!! Stripping off isolated Param node: "
+                     << node->get_friendly_name();
     } else {
       ng_param_list2.push_back(node);
     }
@@ -232,51 +301,79 @@ shared_ptr<Function> IE_Executable::StripOffUnhandledNodes(const shared_ptr<Func
 }
 
 void IE_Executable::InfoSaveInOutIndexMaps() {
-  // Save the input index mappings from CNN's param name to TF/NGraph's input index
-  for (const auto& node : m_network.getFunction()->get_ops()) { // node is a shared_ptr of Node
-      if(node->is_parameter()) {
-          //const ngraph::op::Parameter* param_nodeptr = dynamic_cast<const ngraph::op::Parameter*>(&(*node));
-          //const std::shared_ptr<ngraph::op::Parameter> *param_nodeptr = dynamic_cast<const std::shared_ptr<ngraph::op::Parameter> *>(&node));
-          //std::shared_ptr<ngraph::op::Parameter>& param_node = 
-          const auto& param_node = as_type_ptr<ngraph::op::Parameter>(node);
-          if(param_node) {
-              int idx = (int) m_network.getFunction()->get_parameter_index(param_node);
-              m_map_cnnparam_to_tfidx.insert(std::pair<std::string, int>(node->get_friendly_name(), idx));
-          } else {
-              THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast parameter node = " << node->get_friendly_name() << " !!!\n";
-          }
+  // Save the input index mappings from CNN's param name to TF/NGraph's input
+  // index
+  for (const auto& node :
+       m_network.getFunction()->get_ops()) {  // node is a shared_ptr of Node
+    if (node->is_parameter()) {
+      // const ngraph::op::Parameter* param_nodeptr = dynamic_cast<const
+      // ngraph::op::Parameter*>(&(*node));
+      // const std::shared_ptr<ngraph::op::Parameter> *param_nodeptr =
+      // dynamic_cast<const std::shared_ptr<ngraph::op::Parameter> *>(&node));
+      // std::shared_ptr<ngraph::op::Parameter>& param_node =
+      const auto& param_node = as_type_ptr<ngraph::op::Parameter>(node);
+      if (param_node) {
+        int idx = (int)m_network.getFunction()->get_parameter_index(param_node);
+        m_map_cnnparam_to_tfidx.insert(
+            std::pair<std::string, int>(node->get_friendly_name(), idx));
+      } else {
+        THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast parameter node = "
+                           << node->get_friendly_name() << " !!!\n";
       }
+    }
   }
-  //DBG_ONLY: 
-  //std::cout << "\nIE_Executable ctor, m_map_cnnparam_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
-  ////Dont' check NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(), "Mismatching number of param/input items for orig-func and m_network.getFunction()");
+  // DBG_ONLY:
+  // std::cout << "\nIE_Executable ctor, m_map_cnnparam_to_tfidx " <<
+  // m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const&
+  // pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" <<
+  // pair.second << ", "; } std::cout << "\n";
+  ////Dont' check
+  ///NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(),
+  ///"Mismatching number of param/input items for orig-func and
+  ///m_network.getFunction()");
 
-
-  // Save the output index mappings from CNN's result name to TF tensor's output index
+  // Save the output index mappings from CNN's result name to TF tensor's output
+  // index
   // Example: same numbers of items in each (e.g. 10)
-  // m_network.getOutputsInfo() => Add_359(*), Constant_673, Constant_675, ngraph_output_0(*), ngraph_output_1, ngraph_output_2, ngraph_output_6, ngraph_output_7, ngraph_output_8, ngraph_output_9
-  // m_results = Result_349 (0), Result_350 (1), Result_351 (2), Result_352 (3), Result_353 (4), Result_354 (5), Result_355 (6), Result_356 (7), Result_357 (8), Result_358 (9),
-  // Also, order of Output TF tensors follow the order of m_results, but *NOT* the order of m_network.getOutputsInfo()
-  NGRAPH_CHECK(m_results.size()>=m_network.getOutputsInfo().size(), "Mismatching number of output items");
-  NGRAPH_CHECK(m_results_orig.size()>=m_results.size(), "m_results_orig must be >= m_results");
+  // m_network.getOutputsInfo() => Add_359(*), Constant_673, Constant_675,
+  // ngraph_output_0(*), ngraph_output_1, ngraph_output_2, ngraph_output_6,
+  // ngraph_output_7, ngraph_output_8, ngraph_output_9
+  // m_results = Result_349 (0), Result_350 (1), Result_351 (2), Result_352 (3),
+  // Result_353 (4), Result_354 (5), Result_355 (6), Result_356 (7), Result_357
+  // (8), Result_358 (9),
+  // Also, order of Output TF tensors follow the order of m_results, but *NOT*
+  // the order of m_network.getOutputsInfo()
+  NGRAPH_CHECK(m_results.size() >= m_network.getOutputsInfo().size(),
+               "Mismatching number of output items");
+  NGRAPH_CHECK(m_results_orig.size() >= m_results.size(),
+               "m_results_orig must be >= m_results");
   int idx = 0;
-  for(auto aNodeShPtr : m_results_orig) {
-      string ng_result_name = aNodeShPtr->get_name(); // e.g. Result_350
-      if(m_map_result_to_ngnode.find(ng_result_name) == m_map_result_to_ngnode.end()) {
-              THROW_IE_EXCEPTION << "\n!!! Cannot locate in m_map_result_to_ngnode, ng_result_name = " << ng_result_name << " !!!\n";
-      }
-      string output_name = m_map_result_to_ngnode.at(ng_result_name); // e.g. Constant_673
-      //std::cout << "\nIn IE_Executable::call Prepare output blobs, output_name = " << output_name << ", ng_result_name = " << ng_result_name <<
-      //    ", idx=" << idx << ", tensor outputs[idx].size()=" << outputs[idx]->get_size_in_bytes() << "\n"; // Bani
+  for (auto aNodeShPtr : m_results_orig) {
+    string ng_result_name = aNodeShPtr->get_name();  // e.g. Result_350
+    if (m_map_result_to_ngnode.find(ng_result_name) ==
+        m_map_result_to_ngnode.end()) {
+      THROW_IE_EXCEPTION
+          << "\n!!! Cannot locate in m_map_result_to_ngnode, ng_result_name = "
+          << ng_result_name << " !!!\n";
+    }
+    string output_name =
+        m_map_result_to_ngnode.at(ng_result_name);  // e.g. Constant_673
+    // std::cout << "\nIn IE_Executable::call Prepare output blobs, output_name
+    // = " << output_name << ", ng_result_name = " << ng_result_name <<
+    //    ", idx=" << idx << ", tensor outputs[idx].size()=" <<
+    //    outputs[idx]->get_size_in_bytes() << "\n"; // Bani
 
-      m_map_cnnresult_to_tfidx.insert(std::pair<std::string, int>(output_name, idx));
+    m_map_cnnresult_to_tfidx.insert(
+        std::pair<std::string, int>(output_name, idx));
 
-      idx++;
+    idx++;
   }
-  //DBG_ONLY: 
-  //std::cout << "\nIE_Executable ctor, m_map_cnnresult_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnresult_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  // DBG_ONLY:
+  // std::cout << "\nIE_Executable ctor, m_map_cnnresult_to_tfidx " <<
+  // m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const&
+  // pair : m_map_cnnresult_to_tfidx) { std::cout << pair.first << "->" <<
+  // pair.second << ", "; } std::cout << "\n";
 }
 
-
-} // namespace ngraph_bridge
-} // namespace tensorflow
+}  // namespace ngraph_bridge
+}  // namespace tensorflow

--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -44,6 +44,11 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
   m_network = InferenceEngine::CNNNetwork(func);
   set_parameters_and_results(*func);
 
+  if (std::getenv("NGRAPH_TF_DUMP_GRAPHS")) {
+    auto& name = m_network.getName();
+    m_network.serialize(name + ".xml", name + ".bin");
+  }
+
   NGRAPH_VLOG(2) << "Loading IE CNN network to device " << m_device;
 
   InferenceEngine::Core ie;

--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -40,28 +40,153 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
     }
   }
 
-  NGRAPH_VLOG(2) << "Creating IE CNN network using nGraph function";
-  m_network = InferenceEngine::CNNNetwork(func);
   set_parameters_and_results(*func);
+  m_results_orig = m_results;
+
+#if 1
+  // We need to save the mapping from CNN network's Result nodes to the original NG-function's result-contributing nodes
+  // m_map_result_to_ngnode e.g. (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+  // Also...
+  // OPV/IE CNN doesn't handle Constant nodes that are directly connected to an Output/Result node, save in m_nongraph_const_outputs
+  // (input-const, output-result) e.g. Constant_675->Result_352, ngraph_output_1->Result_350
+  for (const auto& ng_result_node : m_results) { // Note: order of m_results matches with ngfunc's outputs' order, and TF-output-tensors
+      const auto& ng_result_name = ng_result_node->get_name(); // Result_353 or Result_350
+      // Find within the related NGFUNC, the parent/contributing node which feeds to this cnn_result_name
+      const auto& cnn_result_node = ng_result_node->input(0).get_source_output().get_node();
+      const auto& cnn_result_name = cnn_result_node->get_friendly_name(); //  e.g. Constant_675 or ngraph_output_1 // Don't use get_name()!!
+      //BANI_DBG: std::cout << " IE_Executable cnn --> ng_result : " << cnn_result_name << " --> " << ng_result_name << "\n";
+      m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(ng_result_name, cnn_result_name));
+      if(cnn_result_node->is_constant()) {
+          // (input-const, output-result) e.g. Constant_675->Result_352, ngraph_output_1->Result_350
+          m_nongraph_const_outputs.insert(std::pair<std::string, std::string>(cnn_result_name, ng_result_name));
+          const ngraph::op::Constant* const_node = dynamic_cast<const ngraph::op::Constant*>(&(*cnn_result_node));
+          if(const_node) {
+              m_map_cnnconstresult_to_ngnodeptr.insert(std::pair<std::string, void*>(cnn_result_name, (void*)const_node));
+          } else {
+              THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast<const ngraph::op::Constant*>, const-node = " << cnn_result_name << " !!!\n";
+          }
+      }
+  }
+  //BANI_DBG: 
+  // Example: Result_353->Constant_673, Result_350->ngraph_output_1, ...
+  //BANI_DBG: std::cout << "\n*** m_results " << m_results.size() << " ==> "; for (auto& op : m_results) { std::cout << op->get_name() << ", "; } std::cout << "\n";
+  std::cout << "\n*** m_map_result_to_ngnode " << m_map_result_to_ngnode.size() << " ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  //BANI_DBG: 
+  std::cout << "\n*** m_nongraph_const_outputs " << m_nongraph_const_outputs.size() << " ==> "; for (auto const& pair : m_nongraph_const_outputs) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  // Example: Constant_673->Result_353,  ngraph_output_1->Result_350, ...
+
+  NGRAPH_CHECK(m_results.size()==m_map_result_to_ngnode.size(), "Mismatching number of result/output items");
+  for (auto& op : m_results) {
+      if(m_map_result_to_ngnode.count(op->get_name()) == 0) {
+          std::cout << "m_results ==> "; for (auto& op2 : m_results) { std::cout << op2->get_name() << ", "; } std::cout << "\n";
+          THROW_IE_EXCEPTION << "\n!!! m_results op " << op->get_name() << " not found in m_map_result_to_ngnode !!!\n";
+      }
+  }
+#endif
+
+  shared_ptr<Function> func2 = func;
+
+#if 1
+  // Let's don't send disconnected Const -> Result nodes to IE
+  if(m_nongraph_const_outputs.size() > 0) {
+  vector<shared_ptr<ngraph::Node>> ng_result_list2; // (func->get_results().size() - m_nongraph_const_outputs.size());
+  for (auto& opresult : func->get_results()) {
+      const auto& ng_result_name = opresult->get_name();
+      if(m_map_result_to_ngnode.count(ng_result_name) == 1) {
+          const auto& cnn_result_name = m_map_result_to_ngnode.at(ng_result_name);
+          if(m_nongraph_const_outputs.count(cnn_result_name) == 1) {
+              continue;
+          }
+      }
+      ng_result_list2.push_back(opresult);
+  }
+  func2 = make_shared<ngraph::Function>(ng_result_list2, func->get_parameters());
+  func2->set_friendly_name(func->get_friendly_name());
+  }
+#endif
+
+  NGRAPH_VLOG(2) << "Creating IE CNN network using nGraph function";
+  m_network = InferenceEngine::CNNNetwork(func2);
+  ////set_parameters_and_results(*func2); // Don't update again, as we want TF to pass us all inputs & outputs tensors per the original func
+
 
   if (std::getenv("NGRAPH_TF_DUMP_GRAPHS")) {
     auto& name = m_network.getName();
     m_network.serialize(name + ".xml", name + ".bin");
   }
 
-  NGRAPH_VLOG(2) << "Loading IE CNN network to device " << m_device;
 
+  // Bani
+  // Save the input index mappings from CNN's param name to TF/NGraph's input index
+  for (const auto& node : m_network.getFunction()->get_ops()) { // node is a shared_ptr of Node
+      if(node->is_parameter()) {
+          //const ngraph::op::Parameter* param_nodeptr = dynamic_cast<const ngraph::op::Parameter*>(&(*node));
+          //const std::shared_ptr<ngraph::op::Parameter> *param_nodeptr = dynamic_cast<const std::shared_ptr<ngraph::op::Parameter> *>(&node));
+          //std::shared_ptr<ngraph::op::Parameter>& param_node = 
+          const auto& param_node = as_type_ptr<ngraph::op::Parameter>(node);
+          if(param_node) {
+              int idx = (int) m_network.getFunction()->get_parameter_index(param_node);
+              m_map_cnnparam_to_tfidx.insert(std::pair<std::string, int>(node->get_friendly_name(), idx));
+          } else {
+              THROW_IE_EXCEPTION << "\n!!! Cannot dynamic_cast parameter node = " << node->get_friendly_name() << " !!!\n";
+          }
+      }
+  }
+  //BANI_DBG: 
+  std::cout << "\nIE_Executable ctor, m_map_cnnparam_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(), "Mismatching number of param/input items for orig-func and m_network.getFunction()");
+
+#if 1
+  // Bani
+  // Save the output index mappings from CNN's result name to TF tensor's output index
+  // Example: same numbers of items in each (e.g. 10)
+  // m_network.getOutputsInfo() => Add_359(*), Constant_673, Constant_675, ngraph_output_0(*), ngraph_output_1, ngraph_output_2, ngraph_output_6, ngraph_output_7, ngraph_output_8, ngraph_output_9
+  // m_results = Result_349 (0), Result_350 (1), Result_351 (2), Result_352 (3), Result_353 (4), Result_354 (5), Result_355 (6), Result_356 (7), Result_357 (8), Result_358 (9),
+  // Also, order of Output TF tensors follow the order of m_results, but *NOT* the order of m_network.getOutputsInfo()
+  NGRAPH_CHECK(m_results.size()>=m_network.getOutputsInfo().size(), "Mismatching number of output items");
+  NGRAPH_CHECK(m_results_orig.size()>=m_results.size(), "m_results_orig must be >= m_results");
+  int idx = 0;
+  for(auto aNodeShPtr : m_results_orig) {
+      string ng_result_name = aNodeShPtr->get_name(); // e.g. Result_350
+      if(m_map_result_to_ngnode.find(ng_result_name) == m_map_result_to_ngnode.end()) {
+              THROW_IE_EXCEPTION << "\n!!! Cannot locate in m_map_result_to_ngnode, ng_result_name = " << ng_result_name << " !!!\n";
+      }
+      string output_name = m_map_result_to_ngnode.at(ng_result_name); // e.g. Constant_673
+      //std::cout << "\nIn IE_Executable::call Prepare output blobs, output_name = " << output_name << ", ng_result_name = " << ng_result_name <<
+      //    ", idx=" << idx << ", tensor outputs[idx].size()=" << outputs[idx]->get_size_in_bytes() << "\n"; // Bani
+
+      m_map_cnnresult_to_tfidx.insert(std::pair<std::string, int>(output_name, idx));
+
+      idx++;
+  }
+  //BANI_DBG: 
+  std::cout << "\nIE_Executable ctor, m_map_cnnresult_to_tfidx " << m_network.getFunction()->get_friendly_name() << " ==> "; for (auto const& pair : m_map_cnnresult_to_tfidx) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+#endif
+
+  NGRAPH_VLOG(2) << "Loading IE CNN network to device=" << m_device << ", ng-function=" << m_network.getFunction()->get_friendly_name();
   InferenceEngine::Core ie;
   // Load model to the plugin (m_device)
   InferenceEngine::ExecutableNetwork exe_network =
       ie.LoadNetwork(m_network, m_device);
 
   // Create infer request
+  NGRAPH_VLOG(5) << "IE_Executable calling CreateInferRequest() --> " << m_network.getFunction()->get_friendly_name();
   m_infer_req = exe_network.CreateInferRequest();
 }
 
 bool IE_Executable::call(const vector<shared_ptr<runtime::Tensor>>& outputs,
                          const vector<shared_ptr<runtime::Tensor>>& inputs) {
+  NGRAPH_VLOG(5) << "IE_Executable::call BEGIN --> " << m_network.getFunction()->get_friendly_name();
+  
+  // A note about input and output tensor orders:
+  // Example from ng func (the param vectors are in this order for outputs and inputs respectively):
+  //   outs(10) = Add_359(*), Constant_673, Constant_675, ngraph_output_0(*), ngraph_output_1, ngraph_output_2, ngraph_output_6, ngraph_output_7, ngraph_output_8, ngraph_output_9,
+  //     The ones with * are actual dynamic computed results/outs from the IE/CNN
+  //   ins(2) = _arg_import/best_practices_0_0, _arg_import/read_tensor_0_1,
+  // Example Const to ng result map (m_nongraph_const_outputs), helpful for tensor data copying:
+  //   Constant_673->Result_353, Constant_675->Result_352, ngraph_output_1->Result_350, ngraph_output_2->Result_351, 
+  //   ngraph_output_6->Result_355, ngraph_output_7->Result_356, ngraph_output_8->Result_357, ngraph_output_9->Result_358,
+
   InferenceEngine::InputsDataMap input_info = m_network.getInputsInfo();
   if (input_info.size() != inputs.size()) {
     THROW_IE_EXCEPTION
@@ -70,8 +195,18 @@ bool IE_Executable::call(const vector<shared_ptr<runtime::Tensor>>& outputs,
 
   size_t i = 0;
   for (const auto& it : input_info) {
-    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(inputs[i]);
-    m_infer_req.SetBlob(it.first, tv->get_blob());
+    auto input_name = it.first;
+    // Check which TF-tensor-input# this input_name matches with
+    if(m_map_cnnparam_to_tfidx.find(input_name) == m_map_cnnparam_to_tfidx.end()) {
+        THROW_IE_EXCEPTION << "\n!!! Cannot locate in m_map_cnnparam_to_tfidx, input/param = " << input_name << " !!!\n";
+    }
+    int idx_tensor_input = m_map_cnnparam_to_tfidx.at(input_name);
+    if(idx_tensor_input >= inputs.size()) {
+        THROW_IE_EXCEPTION << "\n!!! Bad idx_tensor_input for " << input_name << ", idx_tensor_input = " << idx_tensor_input << " !!!\n";
+    }
+
+    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(inputs[idx_tensor_input]);
+    m_infer_req.SetBlob(input_name, tv->get_blob());
     i++;
   }
 
@@ -82,15 +217,45 @@ bool IE_Executable::call(const vector<shared_ptr<runtime::Tensor>>& outputs,
         << "Function outputs number differ from number of given outputs";
   }
 
-  i = 0;
-  for (const auto& it : output_info) {
-    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(outputs[i]);
-    m_infer_req.SetBlob(it.first, tv->get_blob());
-    i++;
+  NGRAPH_CHECK(m_results_orig.size()==outputs.size(), "Mismatching number of output items between tensors (", outputs.size(), ") and results (", m_results_orig.size() ,")");
+  //NGRAPH_CHECK(m_results.size()==outputs.size(), "Mismatching number of output items between tensors (", outputs.size(), ") and results (", m_results.size() ,")");
+
+  // Shortcut the Const -> Result values
+  for(const auto& it : m_map_cnnconstresult_to_ngnodeptr) {
+      auto output_name = it.first;
+      const ngraph::op::Constant* const_node = (ngraph::op::Constant*)(it.second);
+      if(const_node) {
+          int idx_tensor_output = m_map_cnnresult_to_tfidx.at(output_name);
+          auto num_bytes = shape_size(const_node->get_shape()) * const_node->get_element_type().size();
+          //BANI_DBG: 
+          std::cout << "    ... shortcut value from Const node " << output_name << " to TF Output " << m_nongraph_const_outputs.at(output_name) << ", index=" << ", num_bytes=" << num_bytes << "\n";
+          const void* value = const_node->get_data_ptr();
+          outputs[idx_tensor_output]->write(value, num_bytes);
+      } else {
+          THROW_IE_EXCEPTION << "\n!!! Cannot get const_node = " << output_name << " for value shortcut !!!\n";
+      }
   }
 
+  // Pass the other output tensors
+  for (const auto& it : output_info) {
+    auto output_name = it.first;
+    NGRAPH_CHECK(m_map_cnnresult_to_tfidx.count(output_name) == 1, "!!! Output ", output_name, " not found !!!");
+    int idx_tensor_output = m_map_cnnresult_to_tfidx.at(output_name);
+
+    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(outputs[idx_tensor_output]);
+    //BANI_DBG: 
+    NGRAPH_VLOG(5) << "func => " << m_network.getFunction()->get_friendly_name() <<
+    " Calling m_infer_req.SetBlob for output " << output_name << ", count=" << tv->get_element_count() << 
+    ", network precision=" << it.second->getTensorDesc().getPrecision().name() << 
+    ", tensor type=" << tv->get_element_type().get_type_name() << "\n";
+
+    m_infer_req.SetBlob(output_name, tv->get_blob());
+  }
+
+  NGRAPH_VLOG(5) << "IE_Executable::call -> m_infer_req.Infer() --> " << m_network.getFunction()->get_friendly_name();
   m_infer_req.Infer();
   return true;
 }
-}
-}
+
+} // namespace ngraph_bridge
+} // namespace tensorflow

--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -51,7 +51,7 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
   NGRAPH_VLOG(2) << "Creating IE CNN network using nGraph function";
   m_network = InferenceEngine::CNNNetwork(func2);
   //// CAUTION: set_parameters_and_results(*func2); // Don't update again, as we
-  ///want TF to pass us all inputs & outputs tensors per the original func
+  /// want TF to pass us all inputs & outputs tensors per the original func
 
   if (std::getenv("NGRAPH_TF_DUMP_GRAPHS")) {
     auto& name = m_network.getName();
@@ -328,9 +328,9 @@ void IE_Executable::InfoSaveInOutIndexMaps() {
   // pair : m_map_cnnparam_to_tfidx) { std::cout << pair.first << "->" <<
   // pair.second << ", "; } std::cout << "\n";
   ////Dont' check
-  ///NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(),
+  /// NGRAPH_CHECK(m_map_cnnparam_to_tfidx.size()==func->get_parameters().size(),
   ///"Mismatching number of param/input items for orig-func and
-  ///m_network.getFunction()");
+  /// m_network.getFunction()");
 
   // Save the output index mappings from CNN's result name to TF tensor's output
   // index

--- a/ngraph_bridge/ie_executable.h
+++ b/ngraph_bridge/ie_executable.h
@@ -44,6 +44,7 @@ class IE_Executable final : public Executable {
   InferenceEngine::InferRequest m_infer_req;
   string m_device;
   ngraph::ResultVector m_results_orig;
+  ngraph::ParameterVector m_params_orig;
   std::map<std::string, int> m_map_cnnparam_to_tfidx; // which CNN param maps to which index of the TF input tensor
   std::map<std::string, int> m_map_cnnresult_to_tfidx; // which CNN result maps to which index of the TF output tensor
   std::map<std::string, void*> m_map_cnnconstresult_to_ngnodeptr;

--- a/ngraph_bridge/ie_executable.h
+++ b/ngraph_bridge/ie_executable.h
@@ -45,17 +45,24 @@ class IE_Executable final : public Executable {
   string m_device;
   ngraph::ResultVector m_results_orig;
   ngraph::ParameterVector m_params_orig;
-  std::map<std::string, int> m_map_cnnparam_to_tfidx; // which CNN param maps to which index of the TF input tensor
-  std::map<std::string, int> m_map_cnnresult_to_tfidx; // which CNN result maps to which index of the TF output tensor
+  std::map<std::string, int> m_map_cnnparam_to_tfidx;   // which CNN param maps
+                                                        // to which index of the
+                                                        // TF input tensor
+  std::map<std::string, int> m_map_cnnresult_to_tfidx;  // which CNN result maps
+                                                        // to which index of the
+                                                        // TF output tensor
   std::map<std::string, void*> m_map_cnnconstresult_to_ngnodeptr;
-  std::map<std::string, std::string> m_nongraph_const_outputs; // (input-const, output-result)
-  std::map<std::string, std::string> m_map_result_to_ngnode; // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
-  std::map<std::string, void*> m_map_result_to_ngnodeptr; // same as above one
+  std::map<std::string, std::string>
+      m_nongraph_const_outputs;  // (input-const, output-result)
+  std::map<std::string, std::string>
+      m_map_result_to_ngnode;  // (result, from) e.g. Result_353->Constant_673,
+                               // Result_350->ngraph_output_1
+  std::map<std::string, void*> m_map_result_to_ngnodeptr;  // same as above one
   void InfoSaveResultMaps();
   void InfoSaveInOutIndexMaps();
-  shared_ptr<ngraph::Function> StripOffUnhandledNodes(const shared_ptr<ngraph::Function> &);
-
+  shared_ptr<ngraph::Function> StripOffUnhandledNodes(
+      const shared_ptr<ngraph::Function>&);
 };
 
-} // namespace ngraph_bridge
-} // namespace tensorflow
+}  // namespace ngraph_bridge
+}  // namespace tensorflow

--- a/ngraph_bridge/ie_executable.h
+++ b/ngraph_bridge/ie_executable.h
@@ -43,6 +43,14 @@ class IE_Executable final : public Executable {
   InferenceEngine::CNNNetwork m_network;
   InferenceEngine::InferRequest m_infer_req;
   string m_device;
+  ngraph::ResultVector m_results_orig;
+  std::map<std::string, int> m_map_cnnparam_to_tfidx; // which CNN param maps to which index of the TF input tensor
+  std::map<std::string, int> m_map_cnnresult_to_tfidx; // which CNN result maps to which index of the TF output tensor
+  std::map<std::string, void*> m_map_cnnconstresult_to_ngnodeptr;
+  std::map<std::string, std::string> m_nongraph_const_outputs; // (input-const, output-result)
+  std::map<std::string, std::string> m_map_result_to_ngnode; // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+  std::map<std::string, void*> m_map_result_to_ngnodeptr; // same as above one
 };
-}
-}
+
+} // namespace ngraph_bridge
+} // namespace tensorflow

--- a/ngraph_bridge/ie_executable.h
+++ b/ngraph_bridge/ie_executable.h
@@ -51,6 +51,10 @@ class IE_Executable final : public Executable {
   std::map<std::string, std::string> m_nongraph_const_outputs; // (input-const, output-result)
   std::map<std::string, std::string> m_map_result_to_ngnode; // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
   std::map<std::string, void*> m_map_result_to_ngnodeptr; // same as above one
+  void InfoSaveResultMaps();
+  void InfoSaveInOutIndexMaps();
+  shared_ptr<ngraph::Function> StripOffUnhandledNodes(const shared_ptr<ngraph::Function> &);
+
 };
 
 } // namespace ngraph_bridge

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2460,6 +2460,7 @@ static Status TranslateDirectReduceOp(
         "Expected node to be either a valid logical or arithmetic reduction "
         "type");
   }
+#if 1
   return TranslateReduceOp(
       op, static_input_map, ng_op_map,
       [&op](std::shared_ptr<ng::Node> ng_input,
@@ -2467,6 +2468,23 @@ static Status TranslateDirectReduceOp(
         return ConstructNgNode<T>(op->name(), ng_input, ng_reduction_axes,
                                   keep_dims);
       });
+#endif
+
+#if 0
+  shared_ptr<ng::Node> ng_input, ng_reduction_indices;
+  TF_RETURN_IF_ERROR(
+      GetInputNodes(ng_op_map, op, &ng_input, &ng_reduction_indices));
+  bool keep_dims;
+  if (GetNodeAttr(op->attrs(), "keep_dims", &keep_dims) != Status::OK()) {
+    keep_dims = false;
+  }
+
+  std::shared_ptr<ng::Node> ng_node =
+      ConstructNgNode<T>(op->name(), ng_input, ng_reduction_indices, keep_dims);
+  SaveNgOp(ng_op_map, op->name(), ng_node);
+  return Status::OK();
+#endif
+
 }
 
 static Status TranslateOneHotOp(

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -39,14 +39,14 @@
 #include "ngraph_bridge/ngraph_mark_for_clustering.h"
 #include "ngraph_bridge/ngraph_utils.h"
 
-#include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/algebraic_simplification.hpp"
+#include "ngraph/pass/constant_folding.hpp"
 #include "ngraph/pass/get_output_element_elimination.hpp"
 #include "ngraph/pass/like_replacement.hpp"
 #include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/manager.hpp"
 #include "ngraph/pass/nop_elimination.hpp"
 #include "ngraph/pass/opset1_upgrade.hpp"
-#include "ngraph/pass/constant_folding.hpp"
 #include "ngraph/pass/reshape_elimination.hpp"
 #include "ngraph/pass/reshape_sinking.hpp"
 #include "ngraph/pass/zero_dim_tensor_elimination.hpp"
@@ -2484,7 +2484,6 @@ static Status TranslateDirectReduceOp(
   SaveNgOp(ng_op_map, op->name(), ng_node);
   return Status::OK();
 #endif
-
 }
 
 static Status TranslateOneHotOp(
@@ -4208,63 +4207,72 @@ Status Builder::TranslateGraph(
 
 #if 1
   // Bani
-  NGRAPH_VLOG(1) << "Running optimization passes after TF->NGFUNC TranslateGraph() ...";
-  // ngraph::pass::Manager passes;
-  // passes.register_pass<ng::pass::LikeReplacement>();
-  // passes.register_pass<ng::pass::NopElimination>();
-  // passes.register_pass<ng::pass::ZeroDimTensorElimination>();
-  // passes.register_pass<ng::pass::AlgebraicSimplification>();
-  // passes.register_pass<ngraph::pass::ConstantFolding>();
-  // passes.register_pass<ng::pass::GetOutputElementElimination>();
-  // passes.run_passes(ng_function);
+  NGRAPH_VLOG(1)
+      << "Running optimization passes after TF->NGFUNC TranslateGraph() ...";
+// ngraph::pass::Manager passes;
+// passes.register_pass<ng::pass::LikeReplacement>();
+// passes.register_pass<ng::pass::NopElimination>();
+// passes.register_pass<ng::pass::ZeroDimTensorElimination>();
+// passes.register_pass<ng::pass::AlgebraicSimplification>();
+// passes.register_pass<ngraph::pass::ConstantFolding>();
+// passes.register_pass<ng::pass::GetOutputElementElimination>();
+// passes.run_passes(ng_function);
 
-  // uint64 num_params_before, num_params_after;
-  // do {
-  //   num_params_before = ng_function->get_parameters().size();
-  //   auto itr = ng_function->get_parameters().begin();
-  //   for (auto i=0; i<num_params_before; ++i) {
-  //     const auto& node = ng_function->get_parameters()[i];
-  //     if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
-  //       NGRAPH_VLOG(1) << "!! Found isolated Param node: " << node->get_friendly_name();
-  //       ng_function->get_parameters().erase(itr);
-  //       break;
-  //     } else {
-  //       itr++;
-  //     }
-  //   }
-  //   num_params_after = ng_function->get_parameters().size();
-  // } while(num_params_before != num_params_after);
+// uint64 num_params_before, num_params_after;
+// do {
+//   num_params_before = ng_function->get_parameters().size();
+//   auto itr = ng_function->get_parameters().begin();
+//   for (auto i=0; i<num_params_before; ++i) {
+//     const auto& node = ng_function->get_parameters()[i];
+//     if(node->get_output_size()>0 &&
+//     node->output(0).get_target_inputs().size()==0) {
+//       NGRAPH_VLOG(1) << "!! Found isolated Param node: " <<
+//       node->get_friendly_name();
+//       ng_function->get_parameters().erase(itr);
+//       break;
+//     } else {
+//       itr++;
+//     }
+//   }
+//   num_params_after = ng_function->get_parameters().size();
+// } while(num_params_before != num_params_after);
 
+// auto func_params = ng_function->get_parameters();
+// std::remove_if(func_params.begin(), func_params.end(),
+//   [](std::shared_ptr<ngraph::Node> node) -> bool {
+//     if(node->get_output_size()>0 &&
+//     node->output(0).get_target_inputs().size()==0) {
+//       NGRAPH_VLOG(1) << "!! Found isolated Param node: " <<
+//       node->get_friendly_name();
+//       return true;
+//     }
+//     return false;
+//   });
 
-  
-  // auto func_params = ng_function->get_parameters();
-  // std::remove_if(func_params.begin(), func_params.end(),
-  //   [](std::shared_ptr<ngraph::Node> node) -> bool {
-  //     if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
-  //       NGRAPH_VLOG(1) << "!! Found isolated Param node: " << node->get_friendly_name();
-  //       return true;
-  //     }
-  //     return false;
-  //   });
+// auto func_params = ng_function->get_parameters();
+// ngraph::ParameterVector func_params2;
+// for (auto& node : func_params) { // node is a shared_ptr of Node
+//   //NGRAPH_VLOG(1) << " -> found Param node: " << node->get_friendly_name()
+//   << ", " << node->get_type_info().name << ", #outputs=" <<
+//   node->get_output_size();
+//   // if no output, delete this Arg/Param node
+//   if(node->get_output_size()>0 &&
+//   node->output(0).get_target_inputs().size()==0) {
+//     NGRAPH_VLOG(1) << "!! Stripping off isolated Param node: " <<
+//     node->get_friendly_name();
+//   } else {
+//     func_params2.push_back(node);
+//   }
+// }
+// ng_function = make_shared<ngraph::Function>(ng_function->get_results(),
+// func_params2);
 
-
-  // auto func_params = ng_function->get_parameters();
-  // ngraph::ParameterVector func_params2;
-  // for (auto& node : func_params) { // node is a shared_ptr of Node
-  //   //NGRAPH_VLOG(1) << " -> found Param node: " << node->get_friendly_name() << ", " << node->get_type_info().name << ", #outputs=" << node->get_output_size();
-  //   // if no output, delete this Arg/Param node
-  //   if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
-  //     NGRAPH_VLOG(1) << "!! Stripping off isolated Param node: " << node->get_friendly_name();
-  //   } else {
-  //     func_params2.push_back(node);
-  //   }
-  // }
-  // ng_function = make_shared<ngraph::Function>(ng_function->get_results(), func_params2);
-
-  // NGRAPH_VLOG(5) << "After: " << ng_function->get_parameters().size();
-  // for (const auto& node : ng_function->get_parameters()) { // node is a shared_ptr of Node
-  //   NGRAPH_VLOG(5) << " -> after found Param node: " << node->get_friendly_name();
-  // }
+// NGRAPH_VLOG(5) << "After: " << ng_function->get_parameters().size();
+// for (const auto& node : ng_function->get_parameters()) { // node is a
+// shared_ptr of Node
+//   NGRAPH_VLOG(5) << " -> after found Param node: " <<
+//   node->get_friendly_name();
+// }
 #endif
 
   //

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -39,6 +39,9 @@
 #include "ngraph_bridge/ngraph_mark_for_clustering.h"
 #include "ngraph_bridge/ngraph_utils.h"
 
+#include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/constant_folding.hpp"
+
 using tensorflow::int32;
 using namespace std;
 namespace ng = ngraph;
@@ -4175,6 +4178,11 @@ Status Builder::TranslateGraph(
   // Create the nGraph function.
   //
   ng_function = make_shared<ng::Function>(ng_result_list, ng_parameter_list);
+
+  // Bani
+  ngraph::pass::Manager passes;
+  passes.register_pass<ngraph::pass::ConstantFolding>();
+  passes.run_passes(ng_function);
 
   //
   // Request row-major layout on results.

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -40,7 +40,16 @@
 #include "ngraph_bridge/ngraph_utils.h"
 
 #include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/algebraic_simplification.hpp"
+#include "ngraph/pass/get_output_element_elimination.hpp"
+#include "ngraph/pass/like_replacement.hpp"
+#include "ngraph/pass/manager.hpp"
+#include "ngraph/pass/nop_elimination.hpp"
+#include "ngraph/pass/opset1_upgrade.hpp"
 #include "ngraph/pass/constant_folding.hpp"
+#include "ngraph/pass/reshape_elimination.hpp"
+#include "ngraph/pass/reshape_sinking.hpp"
+#include "ngraph/pass/zero_dim_tensor_elimination.hpp"
 
 using tensorflow::int32;
 using namespace std;
@@ -4179,10 +4188,66 @@ Status Builder::TranslateGraph(
   //
   ng_function = make_shared<ng::Function>(ng_result_list, ng_parameter_list);
 
+#if 1
   // Bani
-  ngraph::pass::Manager passes;
-  passes.register_pass<ngraph::pass::ConstantFolding>();
-  passes.run_passes(ng_function);
+  NGRAPH_VLOG(1) << "Running optimization passes after TF->NGFUNC TranslateGraph() ...";
+  // ngraph::pass::Manager passes;
+  // passes.register_pass<ng::pass::LikeReplacement>();
+  // passes.register_pass<ng::pass::NopElimination>();
+  // passes.register_pass<ng::pass::ZeroDimTensorElimination>();
+  // passes.register_pass<ng::pass::AlgebraicSimplification>();
+  // passes.register_pass<ngraph::pass::ConstantFolding>();
+  // passes.register_pass<ng::pass::GetOutputElementElimination>();
+  // passes.run_passes(ng_function);
+
+  // uint64 num_params_before, num_params_after;
+  // do {
+  //   num_params_before = ng_function->get_parameters().size();
+  //   auto itr = ng_function->get_parameters().begin();
+  //   for (auto i=0; i<num_params_before; ++i) {
+  //     const auto& node = ng_function->get_parameters()[i];
+  //     if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
+  //       NGRAPH_VLOG(1) << "!! Found isolated Param node: " << node->get_friendly_name();
+  //       ng_function->get_parameters().erase(itr);
+  //       break;
+  //     } else {
+  //       itr++;
+  //     }
+  //   }
+  //   num_params_after = ng_function->get_parameters().size();
+  // } while(num_params_before != num_params_after);
+
+
+  
+  // auto func_params = ng_function->get_parameters();
+  // std::remove_if(func_params.begin(), func_params.end(),
+  //   [](std::shared_ptr<ngraph::Node> node) -> bool {
+  //     if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
+  //       NGRAPH_VLOG(1) << "!! Found isolated Param node: " << node->get_friendly_name();
+  //       return true;
+  //     }
+  //     return false;
+  //   });
+
+
+  // auto func_params = ng_function->get_parameters();
+  // ngraph::ParameterVector func_params2;
+  // for (auto& node : func_params) { // node is a shared_ptr of Node
+  //   //NGRAPH_VLOG(1) << " -> found Param node: " << node->get_friendly_name() << ", " << node->get_type_info().name << ", #outputs=" << node->get_output_size();
+  //   // if no output, delete this Arg/Param node
+  //   if(node->get_output_size()>0 && node->output(0).get_target_inputs().size()==0) {
+  //     NGRAPH_VLOG(1) << "!! Stripping off isolated Param node: " << node->get_friendly_name();
+  //   } else {
+  //     func_params2.push_back(node);
+  //   }
+  // }
+  // ng_function = make_shared<ngraph::Function>(ng_function->get_results(), func_params2);
+
+  // NGRAPH_VLOG(5) << "After: " << ng_function->get_parameters().size();
+  // for (const auto& node : ng_function->get_parameters()) { // node is a shared_ptr of Node
+  //   NGRAPH_VLOG(5) << " -> after found Param node: " << node->get_friendly_name();
+  // }
+#endif
 
   //
   // Request row-major layout on results.

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -94,17 +94,12 @@ Status NGraphEncapsulateImpl::Compile(
   BackendManager::LockBackend(backend_name);
   try {
     ng_exec = op_backend->compile(ng_function);
-  } catch (...) {
+  } catch (const std::exception& ex) {
     BackendManager::UnlockBackend(backend_name);
     string fn_name = ng_function->get_friendly_name();
-    Status st =
-        NgraphSerialize("tf_function_" + fn_name + ".json", ng_function);
+    NgraphSerialize("tf_function_" + fn_name + ".json", ng_function);
     BackendManager::ReleaseBackend(backend_name);
-    return errors::Internal(
-        "Failed to compile ng_function.",
-        (st.ok() ? ""
-                 : " Failed to serialize as well with error: " +
-                       st.error_message()));
+    return errors::Internal("Failed to compile ng_function: ", ex.what());
   }
   BackendManager::UnlockBackend(backend_name);
   return Status::OK();

--- a/ngraph_bridge/ngraph_utils.cc
+++ b/ngraph_bridge/ngraph_utils.cc
@@ -350,6 +350,59 @@ Status CheckAxisDimInRange(std::vector<int64> axes, size_t rank) {
   return Status::OK();
 }
 
+#if (CMAKE_BUILD_TYPE == Debug)
+// GDB Debug utility
+void gdb_print_ngfunc_nodes_shptr(const shared_ptr<ngraph::Function>& func) {
+  gdb_print_ngfunc_nodes_funcref(*func);
+}
+
+void gdb_print_ngfunc_nodes_vptr(void* func_addr) {
+  gdb_print_ngfunc_nodes_funcref(*((ngraph::Function*)func_addr));
+}
+
+void gdb_print_ngfunc_nodes_funcref(const ngraph::Function& func) {
+  std::cout << "The ngfunc nodes for " << func.get_friendly_name() << 
+  ", #results=" << func.get_results().size() << ", #params=" << func.get_parameters().size() << 
+  ", #ops=" << func.get_ops().size() << " ==>>\n";
+  for (auto aNodeShPtr : func.get_ordered_ops()) { std::cout << aNodeShPtr->get_friendly_name() << " (" << aNodeShPtr->get_name() << " / " << aNodeShPtr->get_type_name() << "), "; } std::cout << "\n";
+
+  std::map<std::string, std::string> m_map_result_to_ngnode; // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+  auto& orig_ng_results = func.get_results();
+  for (auto aNodeShPtr : orig_ng_results) {
+      m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(aNodeShPtr->get_friendly_name(), "UNKNOWN"));
+  }
+  for (const auto& node : func.get_ops()) {
+      //std::cout << "    trying fn(name) = " << node->get_friendly_name() << "(" << node->get_name() << ", " << node->get_type_name() << ")\n";
+      auto outputs = node->outputs(); // std::vector<Output<Node>>
+      if(outputs.size() == 1) {
+          auto const& outHndl = outputs[0];
+          auto const& targetInputHndls = outHndl.get_target_inputs(); // std::set<Input<Node>> get_target_inputs()
+          //std::cout << "        node's outHndl.get_target_inputs().size() = " << targetInputHndls.size() << "  ==>> "; for (auto x : targetInputHndls) { std::cout << x.get_node()->get_friendly_name() << " (" << x.get_node()->get_name() << " / " << x.get_node()->get_type_name() << "), "; } std::cout << "\n";
+          // TODO: put a check: if we get size > 1, it's Ok as long as all the target inputs have same friendly_name (but diff actual name)
+          if(targetInputHndls.size() > 0) {
+              auto const& outNode = targetInputHndls.begin()->get_node();
+              //std::cout << "        node's outputs.size() == ?, fn(name) = " << outNode->get_friendly_name() << "(" << outNode->get_name() << ", " << outNode->get_type_name() << ")\n";
+              if(m_map_result_to_ngnode.count(outNode->get_friendly_name()) == 0) {
+                  continue; // we are not interested, as it is not a Result_ node
+              }
+              if(outNode->is_output()) {
+                  // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+                  m_map_result_to_ngnode.erase(outNode->get_friendly_name());
+                  m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(outNode->get_friendly_name(), node->get_friendly_name()));
+              }
+          }
+      }
+  }
+  std::cout << "m_map_result_to_ngnode ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+}
+
+Status gdb_serialize_ngfunc(const char* file_name,
+                       const std::shared_ptr<ngraph::Function>& ng_function) {
+  return NgraphSerialize(std::string(file_name), ng_function);          
+}
+#endif
+
+
 Status NgraphSerialize(const std::string& file_name,
                        const std::shared_ptr<ngraph::Function>& ng_function) {
   int json_indentation = 4;

--- a/ngraph_bridge/ngraph_utils.cc
+++ b/ngraph_bridge/ngraph_utils.cc
@@ -361,47 +361,72 @@ void gdb_print_ngfunc_nodes_vptr(void* func_addr) {
 }
 
 void gdb_print_ngfunc_nodes_funcref(const ngraph::Function& func) {
-  std::cout << "The ngfunc nodes for " << func.get_friendly_name() << 
-  ", #results=" << func.get_results().size() << ", #params=" << func.get_parameters().size() << 
-  ", #ops=" << func.get_ops().size() << " ==>>\n";
-  for (auto aNodeShPtr : func.get_ordered_ops()) { std::cout << aNodeShPtr->get_friendly_name() << " (" << aNodeShPtr->get_name() << " / " << aNodeShPtr->get_type_name() << "), "; } std::cout << "\n";
+  std::cout << "The ngfunc nodes for " << func.get_friendly_name()
+            << ", #results=" << func.get_results().size()
+            << ", #params=" << func.get_parameters().size()
+            << ", #ops=" << func.get_ops().size() << " ==>>\n";
+  for (auto aNodeShPtr : func.get_ordered_ops()) {
+    std::cout << aNodeShPtr->get_friendly_name() << " ("
+              << aNodeShPtr->get_name() << " / " << aNodeShPtr->get_type_name()
+              << "), ";
+  }
+  std::cout << "\n";
 
-  std::map<std::string, std::string> m_map_result_to_ngnode; // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
+  std::map<std::string, std::string>
+      m_map_result_to_ngnode;  // (result, from) e.g. Result_353->Constant_673,
+                               // Result_350->ngraph_output_1
   auto& orig_ng_results = func.get_results();
   for (auto aNodeShPtr : orig_ng_results) {
-      m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(aNodeShPtr->get_friendly_name(), "UNKNOWN"));
+    m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(
+        aNodeShPtr->get_friendly_name(), "UNKNOWN"));
   }
   for (const auto& node : func.get_ops()) {
-      //std::cout << "    trying fn(name) = " << node->get_friendly_name() << "(" << node->get_name() << ", " << node->get_type_name() << ")\n";
-      auto outputs = node->outputs(); // std::vector<Output<Node>>
-      if(outputs.size() == 1) {
-          auto const& outHndl = outputs[0];
-          auto const& targetInputHndls = outHndl.get_target_inputs(); // std::set<Input<Node>> get_target_inputs()
-          //std::cout << "        node's outHndl.get_target_inputs().size() = " << targetInputHndls.size() << "  ==>> "; for (auto x : targetInputHndls) { std::cout << x.get_node()->get_friendly_name() << " (" << x.get_node()->get_name() << " / " << x.get_node()->get_type_name() << "), "; } std::cout << "\n";
-          // TODO: put a check: if we get size > 1, it's Ok as long as all the target inputs have same friendly_name (but diff actual name)
-          if(targetInputHndls.size() > 0) {
-              auto const& outNode = targetInputHndls.begin()->get_node();
-              //std::cout << "        node's outputs.size() == ?, fn(name) = " << outNode->get_friendly_name() << "(" << outNode->get_name() << ", " << outNode->get_type_name() << ")\n";
-              if(m_map_result_to_ngnode.count(outNode->get_friendly_name()) == 0) {
-                  continue; // we are not interested, as it is not a Result_ node
-              }
-              if(outNode->is_output()) {
-                  // (result, from) e.g. Result_353->Constant_673, Result_350->ngraph_output_1
-                  m_map_result_to_ngnode.erase(outNode->get_friendly_name());
-                  m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(outNode->get_friendly_name(), node->get_friendly_name()));
-              }
-          }
+    // std::cout << "    trying fn(name) = " << node->get_friendly_name() << "("
+    // << node->get_name() << ", " << node->get_type_name() << ")\n";
+    auto outputs = node->outputs();  // std::vector<Output<Node>>
+    if (outputs.size() == 1) {
+      auto const& outHndl = outputs[0];
+      auto const& targetInputHndls =
+          outHndl.get_target_inputs();  // std::set<Input<Node>>
+                                        // get_target_inputs()
+      // std::cout << "        node's outHndl.get_target_inputs().size() = " <<
+      // targetInputHndls.size() << "  ==>> "; for (auto x : targetInputHndls) {
+      // std::cout << x.get_node()->get_friendly_name() << " (" <<
+      // x.get_node()->get_name() << " / " << x.get_node()->get_type_name() <<
+      // "), "; } std::cout << "\n";
+      // TODO: put a check: if we get size > 1, it's Ok as long as all the
+      // target inputs have same friendly_name (but diff actual name)
+      if (targetInputHndls.size() > 0) {
+        auto const& outNode = targetInputHndls.begin()->get_node();
+        // std::cout << "        node's outputs.size() == ?, fn(name) = " <<
+        // outNode->get_friendly_name() << "(" << outNode->get_name() << ", " <<
+        // outNode->get_type_name() << ")\n";
+        if (m_map_result_to_ngnode.count(outNode->get_friendly_name()) == 0) {
+          continue;  // we are not interested, as it is not a Result_ node
+        }
+        if (outNode->is_output()) {
+          // (result, from) e.g. Result_353->Constant_673,
+          // Result_350->ngraph_output_1
+          m_map_result_to_ngnode.erase(outNode->get_friendly_name());
+          m_map_result_to_ngnode.insert(std::pair<std::string, std::string>(
+              outNode->get_friendly_name(), node->get_friendly_name()));
+        }
       }
+    }
   }
-  std::cout << "m_map_result_to_ngnode ==> "; for (auto const& pair : m_map_result_to_ngnode) { std::cout << pair.first << "->" << pair.second << ", "; } std::cout << "\n";
+  std::cout << "m_map_result_to_ngnode ==> ";
+  for (auto const& pair : m_map_result_to_ngnode) {
+    std::cout << pair.first << "->" << pair.second << ", ";
+  }
+  std::cout << "\n";
 }
 
-Status gdb_serialize_ngfunc(const char* file_name,
-                       const std::shared_ptr<ngraph::Function>& ng_function) {
-  return NgraphSerialize(std::string(file_name), ng_function);          
+Status gdb_serialize_ngfunc(
+    const char* file_name,
+    const std::shared_ptr<ngraph::Function>& ng_function) {
+  return NgraphSerialize(std::string(file_name), ng_function);
 }
 #endif
-
 
 Status NgraphSerialize(const std::string& file_name,
                        const std::shared_ptr<ngraph::Function>& ng_function) {

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -329,6 +329,16 @@ Status CheckAxisDimInRange(std::vector<int64> axes, size_t rank);
 Status NgraphSerialize(const std::string&,
                        const std::shared_ptr<ngraph::Function>&);
 
+#if (CMAKE_BUILD_TYPE == Debug)
+// For gdb debug help...
+// Serialize a ngraph function into a file
+Status gdb_serialize_ngfunc(const char*,
+                       const std::shared_ptr<ngraph::Function>&);
+void gdb_print_ngfunc_nodes_shptr(const shared_ptr<ngraph::Function>&);
+void gdb_print_ngfunc_nodes_funcref(const ngraph::Function&);
+void gdb_print_ngfunc_nodes_vptr(void*);
+#endif
+
 // Dump given string to file
 Status StringToFile(const std::string&, const std::string&,
                     bool sanitize_name = true);

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -333,7 +333,7 @@ Status NgraphSerialize(const std::string&,
 // For gdb debug help...
 // Serialize a ngraph function into a file
 Status gdb_serialize_ngfunc(const char*,
-                       const std::shared_ptr<ngraph::Function>&);
+                            const std::shared_ptr<ngraph::Function>&);
 void gdb_print_ngfunc_nodes_shptr(const shared_ptr<ngraph::Function>&);
 void gdb_print_ngfunc_nodes_funcref(const ngraph::Function&);
 void gdb_print_ngfunc_nodes_vptr(void*);

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -432,8 +432,8 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
     tf_op_shapes.push_back(tf_shape);
     #if defined(ENABLE_OPENVINO)
     // Use pre-allocated tensors to accept outputs of OPV-IE inference
-    Tensor output_tensor(expected_output_datatypes_[i], tf_op_shapes[i]);
-    void* dst_ptr = (void*)DMAHelper::base(&output_tensor);
+    Tensor *p_output_tensor = new Tensor(expected_output_datatypes_[i], tf_op_shapes[i]);
+    void* dst_ptr = (void*)DMAHelper::base(p_output_tensor);
     auto result = backend->create_tensor(ng_op_type, ng_op_shape, dst_ptr);
     #else
     auto result = backend->create_tensor(ng_op_type, ng_op_shape);

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 #include "test/opexecuter.h"
+#include "gtest/gtest.h"
 #include <cstdlib>
 
 using namespace std;
@@ -131,6 +132,7 @@ OpExecuter::~OpExecuter() {}
 void OpExecuter::RunTest(const string& ng_backend_name, float rtol,
                          float atol) {
   vector<Tensor> ngraph_outputs;
+  ngtf_run_status = false;
   ExecuteOnNGraph(ngraph_outputs, ng_backend_name);
   vector<Tensor> tf_outputs;
   ExecuteOnTF(tf_outputs);
@@ -145,6 +147,7 @@ void OpExecuter::RunTest(const string& ng_backend_name, float rtol,
   }
 
   Compare(tf_outputs, ngraph_outputs, rtol, atol);
+  ngtf_run_status = ! ::testing::Test::HasFailure();
 }
 
 // Uses tf_scope to execute on TF
@@ -177,6 +180,19 @@ void OpExecuter::ExecuteOnTF(vector<Tensor>& tf_outputs) {
 // TODO : Refactor
 void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
                                  const string& ng_backend_name) {
+
+#if 0
+  ActivateNGraph();
+  //setenv("NGRAPH_TF_BACKEND", ng_backend_name, 1);
+  ClientSession session(tf_scope_);
+  ASSERT_EQ(Status::OK(), session.Run(sess_run_fetchoutputs_, &ngraph_outputs))
+      << "Failed to run opexecutor on NGTF";
+  for (size_t i = 0; i < ngraph_outputs.size(); i++) {
+    NGRAPH_VLOG(5) << " NGTF output #" << i << ", " << ngraph_outputs[i].DebugString();
+  }
+#endif
+
+#if 1
   Graph graph(OpRegistry::Global());
   TF_CHECK_OK(tf_scope_.ToGraph(&graph));
 
@@ -478,6 +494,8 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
 
   // Release the backend
   BackendManager::ReleaseBackend(ng_backend_type);
+
+#endif
 
 }  // ExecuteOnNGraph
 

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  *******************************************************************************/
 #include "test/opexecuter.h"
-#include "gtest/gtest.h"
 #include <cstdlib>
+#include "gtest/gtest.h"
 
 using namespace std;
 namespace ng = ngraph;
@@ -63,9 +63,8 @@ void OpExecuter::GetNodeData(Graph& graph, NodeMetaData& node_inedge_md,
         *test_op = e->dst();
       }
     }
-    NGRAPH_VLOG(5) << "  GetNodeData Edge: " << e->src()->name()
-                   << "#" << e->src_output()
-                   << " -> " << e->dst()->name() << " #"
+    NGRAPH_VLOG(5) << "  GetNodeData Edge: " << e->src()->name() << "#"
+                   << e->src_output() << " -> " << e->dst()->name() << " #"
                    << e->dst_input();
     // update src's outedge metadata
     node_outedge_md[e->src()].push_back({e->dst(), e->dst_input()});
@@ -147,7 +146,7 @@ void OpExecuter::RunTest(const string& ng_backend_name, float rtol,
   }
 
   Compare(tf_outputs, ngraph_outputs, rtol, atol);
-  ngtf_run_status = ! ::testing::Test::HasFailure();
+  ngtf_run_status = !::testing::Test::HasFailure();
 }
 
 // Uses tf_scope to execute on TF
@@ -157,7 +156,8 @@ void OpExecuter::ExecuteOnTF(vector<Tensor>& tf_outputs) {
   ASSERT_EQ(Status::OK(), session.Run(sess_run_fetchoutputs_, &tf_outputs))
       << "Failed to run opexecutor on TF";
   for (size_t i = 0; i < tf_outputs.size(); i++) {
-    NGRAPH_VLOG(5) << " TF output #" << i << ", " << tf_outputs[i].DebugString();
+    NGRAPH_VLOG(5) << " TF output #" << i << ", "
+                   << tf_outputs[i].DebugString();
   }
 }
 
@@ -180,7 +180,6 @@ void OpExecuter::ExecuteOnTF(vector<Tensor>& tf_outputs) {
 // TODO : Refactor
 void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
                                  const string& ng_backend_name) {
-
 #if 0
   ActivateNGraph();
   //setenv("NGRAPH_TF_BACKEND", ng_backend_name, 1);
@@ -218,8 +217,9 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
   string ng_backend_type;
   BackendManager::GetCurrentlySetBackendName(&ng_backend_type);
 
-  NGRAPH_VLOG(5) << "ExecuteOnNGraph Op " << test_op->type_string() << 
-  ", #inputs " << number_of_inputs << ", backend " << ng_backend_type;
+  NGRAPH_VLOG(5) << "ExecuteOnNGraph Op " << test_op->type_string()
+                 << ", #inputs " << number_of_inputs << ", backend "
+                 << ng_backend_type;
 
   Status status = BackendManager::CreateBackend(ng_backend_type);
   if (!status.ok()) {
@@ -256,8 +256,7 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
 
     Tensor ip_tensor;
     ASSERT_EQ(Status::OK(), GetNodeAttr(ip->attrs(), "value", &ip_tensor))
-        << "Failed to get values from input #" << i << " named "
-        << ip->name();
+        << "Failed to get values from input #" << i << " named " << ip->name();
     input_shapes.push_back(ip_tensor.shape());
     input_dt.push_back(ip_tensor.dtype());
     tf_inputs.push_back(ip_tensor);
@@ -341,8 +340,8 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
   NGRAPH_VLOG(5) << "Added _Retval nodes & Edges ...";
 
   for (const Edge* e : graph.edges()) {
-    NGRAPH_VLOG(5) << "  Edge: " << e->src()->name()
-                   << " -> " << e->dst()->name();
+    NGRAPH_VLOG(5) << "  Edge: " << e->src()->name() << " -> "
+                   << e->dst()->name();
   }
   // For debug
   if (std::getenv("NGRAPH_TF_DUMP_GRAPHS") != nullptr) {
@@ -409,16 +408,16 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
 
     void* src_ptr = (void*)DMAHelper::base(&tf_inputs[i]);
     std::shared_ptr<ngraph::runtime::Tensor> result;
-    #if defined(ENABLE_OPENVINO)
+#if defined(ENABLE_OPENVINO)
     result = backend->create_tensor(ng_et, ng_shape, src_ptr);
-    #else
+#else
     if (ng_backend_type != "CPU") {
       result = backend->create_tensor(ng_et, ng_shape);
       result->write(src_ptr, result->get_element_count() * ng_et.size());
     } else {
       result = backend->create_tensor(ng_et, ng_shape, src_ptr);
     }
-    #endif
+#endif
 
     ng_ip_tensors.push_back(result);
   }
@@ -446,14 +445,15 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
     }
     TensorShape tf_shape(dims);
     tf_op_shapes.push_back(tf_shape);
-    #if defined(ENABLE_OPENVINO)
+#if defined(ENABLE_OPENVINO)
     // Use pre-allocated tensors to accept outputs of OPV-IE inference
-    Tensor *p_output_tensor = new Tensor(expected_output_datatypes_[i], tf_op_shapes[i]);
+    Tensor* p_output_tensor =
+        new Tensor(expected_output_datatypes_[i], tf_op_shapes[i]);
     void* dst_ptr = (void*)DMAHelper::base(p_output_tensor);
     auto result = backend->create_tensor(ng_op_type, ng_op_shape, dst_ptr);
-    #else
+#else
     auto result = backend->create_tensor(ng_op_type, ng_op_shape);
-    #endif
+#endif
     ng_op_tensors.push_back(result);
   }
 
@@ -485,7 +485,8 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
     void* dst_ptr = DMAHelper::base(&output_tensor);
     ng_op_tensors[i]->read(dst_ptr, output_tensor.TotalBytes());
     ngraph_outputs.push_back(output_tensor);
-    NGRAPH_VLOG(5) << "  output #" << i << ", " << ngraph_outputs[i].DebugString();
+    NGRAPH_VLOG(5) << "  output #" << i << ", "
+                   << ngraph_outputs[i].DebugString();
   }
 
   // Clear the tesnors

--- a/test/opexecuter.cpp
+++ b/test/opexecuter.cpp
@@ -62,9 +62,9 @@ void OpExecuter::GetNodeData(Graph& graph, NodeMetaData& node_inedge_md,
         *test_op = e->dst();
       }
     }
-    NGRAPH_VLOG(5) << "Edge between, Src: " << e->src()->name()
-                   << " Src op index " << e->src_output()
-                   << " ,Dst: " << e->dst()->name() << " dst ip index "
+    NGRAPH_VLOG(5) << "  GetNodeData Edge: " << e->src()->name()
+                   << "#" << e->src_output()
+                   << " -> " << e->dst()->name() << " #"
                    << e->dst_input();
     // update src's outedge metadata
     node_outedge_md[e->src()].push_back({e->dst(), e->dst_input()});
@@ -246,7 +246,7 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
     input_dt.push_back(ip_tensor.dtype());
     tf_inputs.push_back(ip_tensor);
 
-    NGRAPH_VLOG(5) << "Extracted tensor  " << i << " "
+    NGRAPH_VLOG(5) << "Extracted tensor #" << i << " "
                    << ip_tensor.DebugString();
   }
 
@@ -254,7 +254,7 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
   for (int i = 0; i < number_of_inputs; i++) {
     if (static_input_indexes_.find(i) != static_input_indexes_.end()) {
       static_input_map.push_back(&tf_inputs[i]);
-      NGRAPH_VLOG(5) << "reading static tensor ptr " << i << " "
+      NGRAPH_VLOG(5) << "  reading static_input tensor index #" << i << " "
                      << (static_input_map[i])->DebugString();
     } else {
       static_input_map.push_back(nullptr);
@@ -322,12 +322,11 @@ void OpExecuter::ExecuteOnNGraph(vector<Tensor>& ngraph_outputs,
     graph.AddEdge(test_op, i, ret_node, 0);
   }
 
-  NGRAPH_VLOG(5) << "Added _Retval nodes ";
+  NGRAPH_VLOG(5) << "Added _Retval nodes & Edges ...";
 
-  NGRAPH_VLOG(5) << "After rewrite *** ";
   for (const Edge* e : graph.edges()) {
-    NGRAPH_VLOG(5) << "Edge between, Src: " << e->src()->name()
-                   << " ,Dst: " << e->dst()->name();
+    NGRAPH_VLOG(5) << "  Edge: " << e->src()->name()
+                   << " -> " << e->dst()->name();
   }
   // For debug
   if (std::getenv("NGRAPH_TF_DUMP_GRAPHS") != nullptr) {

--- a/test/opexecuter.h
+++ b/test/opexecuter.h
@@ -92,6 +92,9 @@ class OpExecuter {
 
   shared_ptr<ng::Function> get_ng_function() { return ng_function; }
 
+  bool tf_run_status = true;
+  bool ngtf_run_status = true;
+
  private:
   Scope tf_scope_;
   const string test_op_type_;
@@ -99,6 +102,7 @@ class OpExecuter {
   set<int> static_input_indexes_;
   const vector<DataType> expected_output_datatypes_;
   const std::vector<Output> sess_run_fetchoutputs_;
+
 
   void GetNodeData(Graph& graph, NodeMetaData& node_inedge_md,
                    NodeMetaData& node_outedge_md, NodeOutEdges& node_outedges,

--- a/test/opexecuter.h
+++ b/test/opexecuter.h
@@ -103,7 +103,6 @@ class OpExecuter {
   const vector<DataType> expected_output_datatypes_;
   const std::vector<Output> sess_run_fetchoutputs_;
 
-
   void GetNodeData(Graph& graph, NodeMetaData& node_inedge_md,
                    NodeMetaData& node_outedge_md, NodeOutEdges& node_outedges,
                    Node** test_op);

--- a/test/test_math_ops.cpp
+++ b/test/test_math_ops.cpp
@@ -428,10 +428,10 @@ TEST(MathOps, Sum) {
 
   std::vector<int> v = {1, 2, 3, 4};
   Tensor A(DT_INT32, TensorShape({dim1, dim2}));
-  vector<bool> v_keep_dims = {true, false};
+  vector<bool> v_keep_dims = {false}; //{true, false};
   // axis at which the dimension will be inserted
   // should be -rank <= axis < rank
-  vector<int> v_axis = {-1, 0, 1};
+  vector<int> v_axis = {1}; //{-1, 0, 1};
   int counter = 1;
   for (auto axis : v_axis) {
     for (auto keep_dims : v_keep_dims) {

--- a/test/test_math_ops.cpp
+++ b/test/test_math_ops.cpp
@@ -432,8 +432,10 @@ TEST(MathOps, Sum) {
   // axis at which the dimension will be inserted
   // should be -rank <= axis < rank
   vector<int> v_axis = {-1, 0, 1};
+  int counter = 1;
   for (auto axis : v_axis) {
     for (auto keep_dims : v_keep_dims) {
+      NGRAPH_VLOG(5) << "========>> Running Sum sub-test #" << counter++ << ", axis=" << axis << ", keep_dims=" << keep_dims;
       Scope root = Scope::NewRootScope();
       auto keep_dims_attr = ops::Sum::Attrs().KeepDims(keep_dims);
 

--- a/test/test_math_ops.cpp
+++ b/test/test_math_ops.cpp
@@ -485,20 +485,23 @@ INSTANTIATE_TEST_CASE_P(
 
 // Test op: Sum with & without keep dims & with both positive & negative axis
 TEST(MathOps, Sum) {
-
-  std::vector<int> vals = {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6};
-  vector<TensorShape> tshapes = { {2,3}, {2,2,3}, {6,2}, {2,4,3}, {4,3,2,1}, {1,2,3,4}, {3,1,2,4,1}  };
+  std::vector<int> vals = {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6,
+                           1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6};
+  vector<TensorShape> tshapes = {{2, 3},         {2, 2, 3},    {6, 2},
+                                 {2, 4, 3},      {4, 3, 2, 1}, {1, 2, 3, 4},
+                                 {3, 1, 2, 4, 1}};
   vector<bool> v_keep_dims = {true, false};
   std::vector<std::string> run_results;
   int counter = 1;
-  for(auto tshp : tshapes) {
+  for (auto tshp : tshapes) {
     Tensor A(DT_INT32, TensorShape(tshp));
     vector<int> v_axis(tshp.dims());
     std::iota(v_axis.begin(), v_axis.end(), 0);
     for (auto axis : v_axis) {
       for (auto keep_dims : v_keep_dims) {
-        NGRAPH_VLOG(5) << "========>> Running Sum sub-test #" << counter++ << 
-        ", tensor-shape=" << tshp << ", axis=" << axis << ", keep_dims=" << keep_dims;
+        NGRAPH_VLOG(5) << "========>> Running Sum sub-test #" << counter++
+                       << ", tensor-shape=" << tshp << ", axis=" << axis
+                       << ", keep_dims=" << keep_dims;
         Scope root = Scope::NewRootScope();
         auto keep_dims_attr = ops::Sum::Attrs().KeepDims(keep_dims);
 
@@ -509,25 +512,31 @@ TEST(MathOps, Sum) {
 
         auto R = ops::Sum(root, A, axis, keep_dims_attr);
         std::vector<Output> sess_run_fetchoutputs = {R};
-        OpExecuter opexecuter(root, "Sum", static_input_indexes, output_datatypes,
-                              sess_run_fetchoutputs);
+        OpExecuter opexecuter(root, "Sum", static_input_indexes,
+                              output_datatypes, sess_run_fetchoutputs);
 
         opexecuter.RunTest();
         // run_results.push_back(
-        //   std::format("Status {} -> tensor-shape={}, axis={}, keep_dims={}", 
-        //   (opexecuter.ngtf_run_status ? "PASS" : "FAIL"), tshp, axis, keep_dims)
+        //   std::format("Status {} -> tensor-shape={}, axis={}, keep_dims={}",
+        //   (opexecuter.ngtf_run_status ? "PASS" : "FAIL"), tshp, axis,
+        //   keep_dims)
         // );
-        
-        run_results.push_back(std::string("Status ") + (LastCompareSuccessful() ? "  PASS" : "* FAIL") + " -> " 
-          + "tensor-shape=" + tshp.DebugString() + ", axis=" + std::to_string(axis) + ", keep_dims=" + std::to_string(keep_dims));
-        // run_results.push_back(std::string("Status ") + (::testing::Test::HasFailure() ? "FAIL" : "PASS") + " -> " 
-        //   + "tensor-shape=" + tshp.DebugString() + ", axis=" + std::to_string(axis) + ", keep_dims=" + std::to_string(keep_dims));
+
+        run_results.push_back(std::string("Status ") +
+                              (LastCompareSuccessful() ? "  PASS" : "* FAIL") +
+                              " -> " + "tensor-shape=" + tshp.DebugString() +
+                              ", axis=" + std::to_string(axis) +
+                              ", keep_dims=" + std::to_string(keep_dims));
+        // run_results.push_back(std::string("Status ") +
+        // (::testing::Test::HasFailure() ? "FAIL" : "PASS") + " -> "
+        //   + "tensor-shape=" + tshp.DebugString() + ", axis=" +
+        //   std::to_string(axis) + ", keep_dims=" + std::to_string(keep_dims));
       }
     }
   }
 
   std::cout << "\nReport of sub-tests...\n";
-  for(auto & str: run_results) {
+  for (auto& str : run_results) {
     std::cout << str + "\n";
   }
   std::cout << "\n";

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -341,9 +341,7 @@ bool Compare(std::vector<string> desired, std::vector<string> actual) {
   return true;
 }
 
-bool LastCompareSuccessful() {
-  return _LastCompareSuccessful;
-}
+bool LastCompareSuccessful() { return _LastCompareSuccessful; }
 
 Status CreateSession(const string& graph_filename, const string& backend_name,
                      unique_ptr<tf::Session>& session) {

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -31,6 +31,8 @@ namespace ngraph_bridge {
 
 namespace testing {
 
+static bool _LastCompareSuccessful = false;
+
 void ActivateNGraph() {
   setenv("NGRAPH_TF_DISABLE_DEASSIGN_CLUSTERS", "1", 1);
   unsetenv("NGRAPH_TF_DISABLE");
@@ -323,6 +325,7 @@ void Compare(const Tensor& T1, const Tensor& T2, float rtol, float atol) {
 
     EXPECT_TRUE(is_comparable) << " TF output " << a << endl
                                << " NG output " << b;
+    _LastCompareSuccessful = is_comparable;
   }
 }
 
@@ -336,6 +339,10 @@ bool Compare(std::vector<string> desired, std::vector<string> actual) {
     }
   }
   return true;
+}
+
+bool LastCompareSuccessful() {
+  return _LastCompareSuccessful;
 }
 
 Status CreateSession(const string& graph_filename, const string& backend_name,

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -150,6 +150,8 @@ void Compare(const Tensor& T1, const Tensor& T2,
 // Compares Tensors considering tolerance
 void Compare(Tensor& T1, Tensor& T2, float tol);
 
+bool LastCompareSuccessful();
+
 Status CreateSession(const string& graph_filename, const string& backend_name,
                      unique_ptr<tf::Session>& session);
 


### PR DESCRIPTION
* pre-allocate output/result tensors in heap, for C++ unit testing of OPV-IE
* IE tensor ordering, Const-Result checks and removal of isolated Param nodes
* add example code for parameterized C++ unit tests