### PR TITLE
allow branch/tag/commit for version in download_repo()

### DIFF
--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -507,7 +507,9 @@ def download_repo(target_name, repo, version, submodule_update=False):
     is_branch = ""
     try:
         is_branch = subprocess.check_output(
-            "git show-ref --verify refs/heads/" + version, shell=True).rstrip()
+            "git show-ref --verify refs/heads/" + version +
+            " refs/remotes/origin/" + version,
+            shell=True).rstrip()
     except:
         pass
     if is_branch == "":

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -507,8 +507,8 @@ def download_repo(target_name, repo, version, submodule_update=False):
     is_branch = ""
     try:
         is_branch = subprocess.check_output(
-            "git show-ref --verify refs/heads/" + version +
-            " refs/remotes/origin/" + version,
+            "git show-ref refs/heads/" + version + " refs/remotes/origin/" +
+            version,
             shell=True).rstrip()
     except:
         pass


### PR DESCRIPTION
Allow build_ngtf.py to specify any branch-name, tag or commit-id to be used as version for downloading a git repo