### PR TITLE
Fix path of downloaded pretrained model when running CI RN50 job

### DIFF
--- a/tools/test_utils.py
+++ b/tools/test_utils.py
@@ -240,6 +240,7 @@ def run_resnet50_from_artifacts(ngraph_tf_src_dir, artifact_dir, batch_size,
 
     os.chdir(root_pwd)
 
+
 def run_resnet50_infer_from_artifacts(artifact_dir, batch_size, iterations):
     root_pwd = os.getcwd()
     artifact_dir = os.path.abspath(artifact_dir)
@@ -249,7 +250,8 @@ def run_resnet50_infer_from_artifacts(artifact_dir, batch_size, iterations):
         install_ngraph_bridge(artifact_dir)
 
     # Check/download pretrained model
-    pretrained_models_dir = os.path.abspath(os.path.join(root_pwd, '../pretrained_models'))
+    pretrained_models_dir = os.path.abspath(
+        os.path.join(root_pwd, '../pretrained_models'))
     if not os.path.exists(pretrained_models_dir):
         os.mkdir(pretrained_models_dir, 0o755)
     os.chdir(pretrained_models_dir)

--- a/tools/test_utils.py
+++ b/tools/test_utils.py
@@ -240,105 +240,6 @@ def run_resnet50_from_artifacts(ngraph_tf_src_dir, artifact_dir, batch_size,
 
     os.chdir(root_pwd)
 
-
-# See https://github.com/IntelAI/models/blob/master/benchmarks/image_recognition/tensorflow/resnet50v1_5/README.md#fp32-inference-instructions
-def run_intelaimodels_resnet50_infer_from_artifacts(
-        ngraph_tf_src_dir, artifact_dir, batch_size, iterations):
-    root_pwd = os.getcwd(
-    )  # e.g. /localdisk/buildkite-agent/builds/aipg-ra-skx-168-2/ngraph/ngtf-cpu-ubuntu
-    artifact_dir = os.path.abspath(artifact_dir)
-    if not os.path.exists(artifact_dir):
-        raise Exception("Can't find artifact dir: " + artifact_dir)
-    ngraph_tf_src_dir = os.path.abspath(ngraph_tf_src_dir)
-    if (len(glob.glob(artifact_dir + "/ngraph_tensorflow_bridge-*.whl")) == 0):
-        install_ngraph_bridge(artifact_dir)
-
-    # Check/download pretrained model
-    pretrained_models_dir = root_pwd + '/pretrained_models'
-    if not os.path.exists(pretrained_models_dir):
-        os.mkdir(pretrained_models_dir, 0o755)
-    os.chdir(pretrained_models_dir)
-    pretrained_model = pretrained_models_dir + '/resnet50_v1.pb'
-    if not os.path.exists(pretrained_model):
-        # wget https://zenodo.org/record/2535873/files/resnet50_v1.pb
-        command_executor(
-            ['wget', 'https://zenodo.org/record/2535873/files/resnet50_v1.pb'],
-            verbose=True)
-        if not os.path.exists(pretrained_model):
-            raise Exception("Can't download pretrained model: " +
-                            pretrained_model)
-    else:
-        print("Using existing pretrained model file: " + pretrained_model)
-
-    # Now clone the IntelAI repo and proceed
-    os.chdir(root_pwd)
-    IntelAIModels_dir = root_pwd + '/IntelAI-MODELS'
-    if not os.path.exists(IntelAIModels_dir):
-        call([
-            'git', 'clone', 'https://github.com/IntelAI/models.git',
-            'IntelAI-MODELS'
-        ])
-        os.chdir('IntelAI-MODELS')
-        call(['git', 'checkout', 'ae52473'])  # == master as of 2020-04-21
-
-    # Update file: ./models/image_recognition/tensorflow/resnet50v1_5/inference/eval_image_classifier_inference.py
-    script_file = IntelAIModels_dir + '/models/image_recognition/tensorflow/resnet50v1_5/inference/eval_image_classifier_inference.py'
-    if not os.path.exists(script_file):
-        raise Exception("Can't find script file: " + script_file)
-    # ^[ ]*import[ ]*ngraph_bridge[ ]*$
-    res = subprocess.run(
-        'grep \'import ngraph_bridge\' ' + script_file + ' | wc -l',
-        shell=True,
-        stdout=subprocess.PIPE)
-    if res.stdout.decode('utf-8').rstrip() == '0':
-        print('Updating script with \'import ngraph_bridge\' ...')
-        with open(script_file, 'r') as filedesc:
-            data = filedesc.readlines()  # data[0], data[1], ...
-        data[166] = data[166] + '    import ngraph_bridge\n'
-        with open(script_file, 'w') as filedesc:
-            filedesc.writelines(data)
-        res = subprocess.run(
-            'grep \'import ngraph_bridge\' ' + script_file + ' | wc -l',
-            shell=True,
-            stdout=subprocess.PIPE)
-        if res.stdout.decode('utf-8').rstrip() == 0:
-            raise Exception("Can't add 'import ngraph_bridge' to script file: "
-                            + script_file)
-
-    # Setup the env flags
-    import psutil
-    num_cores = int(psutil.cpu_count(logical=False))
-    print("OMP_NUM_THREADS: %s " % str(num_cores))
-    os.environ['OMP_NUM_THREADS'] = str(num_cores)
-    os.environ["KMP_AFFINITY"] = 'granularity=fine,compact,1,0'
-
-    # Delete older logs
-    log_dir = IntelAIModels_dir + '/benchmarks/common/tensorflow/logs'
-    if os.path.exists(log_dir):
-        #os.rmdir(log_dir)
-        filelist = glob.glob(os.path.join(log_dir, "*.log"))
-        for f in filelist:
-            os.remove(f)
-
-    os.chdir(IntelAIModels_dir + '/benchmarks/')
-    # python launch_benchmark.py  --in-graph resnet50_v1.pb  --model-name resnet50v1_5
-    # --framework tensorflow  --precision fp32  --mode inference  --batch-size=1  --socket-id=0
-    cmd = [
-        'python',
-        'launch_benchmark.py',
-        '--in-graph',
-        pretrained_model,
-        '--model-name resnet50v1_5',
-        '--framework tensorflow',
-        '--precision fp32',
-        '--mode inference',
-        '--batch-size=1',
-        '--socket-id=0',
-    ]
-    command_executor(cmd, verbose=True)
-    os.chdir(root_pwd)
-
-
 def run_resnet50_infer_from_artifacts(artifact_dir, batch_size, iterations):
     root_pwd = os.getcwd()
     artifact_dir = os.path.abspath(artifact_dir)
@@ -348,7 +249,7 @@ def run_resnet50_infer_from_artifacts(artifact_dir, batch_size, iterations):
         install_ngraph_bridge(artifact_dir)
 
     # Check/download pretrained model
-    pretrained_models_dir = root_pwd + '/pretrained_models'
+    pretrained_models_dir = os.path.abspath(os.path.join(root_pwd, '../pretrained_models'))
     if not os.path.exists(pretrained_models_dir):
         os.mkdir(pretrained_models_dir, 0o755)
     os.chdir(pretrained_models_dir)


### PR DESCRIPTION
* Download the pretrained model outside of the git working directory to avoid having to download it again for each job in the CI pipeline
* Remove duplicated unused method