### PR TITLE
Minor refactor of tensor allocation in executor

### DIFF
--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -178,9 +178,9 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
     const char* cache_depth_specified =
         std::getenv("NGRAPH_TF_FUNCTION_CACHE_ITEM_DEPTH");
     if (cache_depth_specified != nullptr) {
-      my_function_cache_depth_in_items = atoi(cache_depth_specified);
+      m_function_cache_depth_in_items = atoi(cache_depth_specified);
     }
-    if (m_ng_exec_map.size() >= my_function_cache_depth_in_items) {
+    if (m_ng_exec_map.size() >= m_function_cache_depth_in_items) {
       evicted_ng_exec = m_ng_exec_map[m_lru.back()];
       m_ng_exec_map.erase(m_lru.back());
       m_serialized_ng_function_map.erase(evicted_ng_exec);

--- a/ngraph_bridge/ngraph_encapsulate_impl.cc
+++ b/ngraph_bridge/ngraph_encapsulate_impl.cc
@@ -261,8 +261,6 @@ Status NGraphEncapsulateImpl::GetNgExecutable(
   return Status::OK();
 }
 
-// Allocate tensors for output results.  Creates ngraph output tensors using
-// tensorflow tensors required to execute ngraph function
 Status NGraphEncapsulateImpl::AllocateNGTensors(
     const std::vector<Tensor>& tf_tensors,
     vector<shared_ptr<ng::runtime::Tensor>>& ng_tensors) {

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -58,19 +58,9 @@ class NGraphEncapsulateImpl {
                          std::vector<const Tensor*>& static_input_map,
                          std::shared_ptr<Executable>& ng_exec);
 
-  // Allocate tensors for input arguments. Creates ngraph input tensors using
-  // tensorflow tensors required to execute ngraph function
-  Status AllocateNGInputTensors(
-      const std::vector<Tensor>& tf_input_tensors,
-      const std::shared_ptr<Executable>& ng_exec,
-      vector<shared_ptr<ng::runtime::Tensor>>& ng_inputs);
-
-  // Allocate tensors for output results.  Creates ngraph output tensors using
-  // tensorflow tensors required to execute ngraph function
-  Status AllocateNGOutputTensors(
-      const std::vector<Tensor*>& tf_output_tensors,
-      const std::shared_ptr<Executable>& ng_exec,
-      vector<shared_ptr<ng::runtime::Tensor>>& ng_outputs);
+  // Allocate nGraph tensors for TF tensors
+  Status AllocateNGTensors(const std::vector<Tensor>& tf_tensors,
+                           vector<shared_ptr<ng::runtime::Tensor>>& ng_tensors);
 
   // Clear all maps with ng_exec as keys
   void ClearExecMaps();

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -79,7 +79,7 @@ class NGraphEncapsulateImpl {
 
   void SetNgraphCluster(const int& cluster) { m_ngraph_cluster = cluster; }
 
-  const int& GetFunctionCache() { return my_function_cache_depth_in_items; }
+  const int& GetFunctionCache() { return m_function_cache_depth_in_items; }
 
   const int& GetNumberOfOutputs() { return m_number_outputs; }
 
@@ -96,12 +96,6 @@ class NGraphEncapsulateImpl {
   void SetOpBackend(const string& backend_name) {
     m_op_backend_name = backend_name;
   }
-
-  bool GetLogCopies() { return log_copies; }
-
-  void SetLogCopies(bool value) { log_copies = value; }
-
-  const string GetCopyLog() { return copy_log_str.str(); }
 
   const std::vector<bool> GetStaticInputVector() { return m_input_is_static; }
 
@@ -137,17 +131,14 @@ class NGraphEncapsulateImpl {
   Graph m_graph;
 
  private:
-  int number_of_copies = 0;
   int m_ngraph_cluster{-1};
   int m_graph_id{-1};
-  int my_function_cache_depth_in_items = 16;
+  int m_function_cache_depth_in_items = 16;
   int m_number_outputs = -1;
   int m_number_inputs = -1;
   int my_instance_id{0};
   string m_op_backend_name;
   string m_name;
-  std::stringstream copy_log_str;
-  bool log_copies = false;
   std::vector<bool> m_input_is_static;
   std::list<std::string> m_lru;
   static int s_instance_count;
@@ -159,11 +150,9 @@ class NGraphEncapsulateImpl {
   std::unordered_map<std::string, std::shared_ptr<Executable>> m_ng_exec_map;
   std::unordered_map<std::shared_ptr<Executable>, std::string>
       m_serialized_ng_function_map;
-
-  int m_depth{2};  // TODO make this settable
 };
 
 }  // namespace ngraph_bridge
-
 }  // namespace tensorflow
+
 #endif  // NGRAPH_TF_ENCAPSULATE_IMPL_H_

--- a/ngraph_bridge/ngraph_encapsulate_impl.h
+++ b/ngraph_bridge/ngraph_encapsulate_impl.h
@@ -58,7 +58,7 @@ class NGraphEncapsulateImpl {
                          std::vector<const Tensor*>& static_input_map,
                          std::shared_ptr<Executable>& ng_exec);
 
-  // Allocate nGraph tensors for TF tensors
+  // Allocate nGraph tensors for given TF tensors
   Status AllocateNGTensors(const std::vector<Tensor>& tf_tensors,
                            vector<shared_ptr<ng::runtime::Tensor>>& ng_tensors);
 

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -261,8 +261,8 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   int ng_input_tensor_size_in_bytes = 0;
   {
     NG_TRACE("Input: maybe create", name(), "");
-    OP_REQUIRES_OK(ctx, ng_encap_impl_.AllocateNGInputTensors(
-                            tf_input_tensors, ng_exec, ng_inputs));
+    OP_REQUIRES_OK(
+        ctx, ng_encap_impl_.AllocateNGTensors(tf_input_tensors, ng_inputs));
   }
 
   NGRAPH_VLOG(4) << "NGraphEncapsulateOp::Compute allocated argument tensors "
@@ -271,8 +271,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   // Allocate tensors for the output results.
   vector<shared_ptr<ng::runtime::Tensor>> ng_outputs;
   int ng_output_tensor_size_in_bytes = 0;
-  std::vector<Tensor*> tf_output_tensors;
-  std::vector<std::pair<void*, shared_ptr<ng::runtime::Tensor>>> output_caches;
+  std::vector<Tensor> tf_output_tensors;
   {
     NG_TRACE("Output: maybe create", name(), "");
     for (auto i = 0; i < ng_exec->get_results().size(); i++) {
@@ -288,7 +287,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       TensorShape tf_shape(dims);
       Tensor* output_tensor = nullptr;
       OP_REQUIRES_OK(ctx, ctx->allocate_output(i, tf_shape, &output_tensor));
-      tf_output_tensors.push_back(output_tensor);
+      tf_output_tensors.push_back(*output_tensor);
 
       // Make sure the nGraph-inferred element type agrees with what TensorFlow
       // expected.
@@ -302,8 +301,8 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
                            "the element type expected by TensorFlow"));
     }
 
-    OP_REQUIRES_OK(ctx, ng_encap_impl_.AllocateNGOutputTensors(
-                            tf_output_tensors, ng_exec, ng_outputs));
+    OP_REQUIRES_OK(
+        ctx, ng_encap_impl_.AllocateNGTensors(tf_output_tensors, ng_outputs));
   }
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute allocated result tensors for cluster "

--- a/test/cpp_tests_list_IECPU.txt
+++ b/test/cpp_tests_list_IECPU.txt
@@ -17,8 +17,6 @@ TFExec.SingleGraphOn2Threads
 TFExec.axpy
 tf_exec.BatchMatMul
 EncapsulateOp.GetNgExecutable
-EncapsulateOp.AllocateNGInputTensors
-EncapsulateOp.AllocateNGOutputTensors
 OpByOpCapability.Backend
 MathOps.Sum
 MathOps.Mean


### PR DESCRIPTION
* Unify methods to allocate nGraph input and output tensors
* Avoid the use of internal TF DMA helper method