### PR TITLE
Use "SelectV2" for select translation

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -3087,7 +3087,7 @@ const static std::map<
         {"Reshape", TranslateReshapeOp},
         {"Rsqrt", TranslateRsqrtOp},
         {"ScatterNd", TranslateScatterNdOp},
-        {"Select", TranslateSelectOp},
+        {"SelectV2", TranslateSelectOp},
         {"Shape", TranslateShapeOp},
         {"Sigmoid", TranslateUnaryOp<opset::Sigmoid>},
         {"Sin", TranslateUnaryOp<opset::Sin>},

--- a/ngraph_bridge/ngraph_deassign_clusters.cc
+++ b/ngraph_bridge/ngraph_deassign_clusters.cc
@@ -37,7 +37,6 @@
 using namespace std;
 
 namespace tensorflow {
-
 namespace ngraph_bridge {
 
 //
@@ -218,5 +217,4 @@ Status DeassignClusters(Graph* graph) {
 }
 
 }  // namespace ngraph_bridge
-
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -354,7 +354,7 @@ const std::map<std::string, ConfirmationFunction>& GetConfirmationMap() {
     confirmation_function_map["Reshape"] = SimpleConfirmationFunction();
     confirmation_function_map["Rsqrt"] = SimpleConfirmationFunction();
     confirmation_function_map["ScatterNd"] = SimpleConfirmationFunction();
-    confirmation_function_map["Select"] = SimpleConfirmationFunction();
+    confirmation_function_map["SelectV2"] = SimpleConfirmationFunction();
     confirmation_function_map["Shape"] = SimpleConfirmationFunction();
     confirmation_function_map["Sigmoid"] = SimpleConfirmationFunction();
     confirmation_function_map["Sign"] = SimpleConfirmationFunction();
@@ -521,7 +521,7 @@ const TypeConstraintMap& GetTypeConstraintMap() {
     type_constraint_map["Rsqrt"]["T"] = NGraphDTypes();
     type_constraint_map["ScatterNd"]["T"] = NGraphDTypes();
     type_constraint_map["ScatterNd"]["Tindices"] = NGraphIndexDTypes();
-    type_constraint_map["Select"]["T"] = NGraphDTypes();
+    type_constraint_map["SelectV2"]["T"] = NGraphDTypes();
     type_constraint_map["Shape"]["T"] = NGraphDTypes();
     type_constraint_map["Shape"]["out_type"] = NGraphIndexDTypes();
     type_constraint_map["Sigmoid"]["T"] = NGraphNumericDTypes();
@@ -713,7 +713,7 @@ GetTFToNgOpMap() {
       {"Relu", {std::make_shared<opset::Relu>()}},
       {"Relu6", {std::make_shared<opset::Clamp>()}},
       {"Rsqrt", {constant, std::make_shared<opset::Power>()}},
-      {"Select", {std::make_shared<opset::Select>()}},
+      {"SelectV2", {std::make_shared<opset::Select>()}},
       {"Reshape", {std::make_shared<opset::Reshape>()}},
       {"ScatterNd", {constant, std::make_shared<ngraph::op::ScatterNDAdd>()}},
       {"Shape", {std::make_shared<opset::ShapeOf>()}},

--- a/test/python/test_select.py
+++ b/test/python/test_select.py
@@ -68,7 +68,7 @@ class TestSelect(NgraphTest):
 
     def test_select_complexshape1(self):
         a = np.random.randint(2, size=[7])
-        x = np.random.uniform(0, 11, [7, 3, 2, 1])
+        x = np.random.randint(0, 11, [7, 3, 2, 1])
 
         p = tf.compat.v1.placeholder(dtype=tf.bool)
         out = tf.where(p, x, x)
@@ -81,7 +81,7 @@ class TestSelect(NgraphTest):
 
     def test_select_complexshape2(self):
         a = np.random.randint(2, size=[7])
-        x = np.random.uniform(0, 11, [7, 3, 2, 7])
+        x = np.random.randint(0, 11, [7, 3, 2, 7])
 
         p = tf.compat.v1.placeholder(dtype=tf.bool)
         out = tf.where(p, x, x)
@@ -94,7 +94,7 @@ class TestSelect(NgraphTest):
 
     def test_select_complexshape3(self):
         a = np.random.randint(2, size=[5])
-        x = np.random.uniform(0, 11, [5, 3, 1])
+        x = np.random.randint(0, 11, [5, 3, 1])
 
         p = tf.compat.v1.placeholder(dtype=tf.bool)
         out = tf.where(p, x, x)

--- a/test/python/tests_linux_ie_cpu.txt
+++ b/test/python/tests_linux_ie_cpu.txt
@@ -53,6 +53,9 @@ test_elementwise_ops.TestElementwiseOperations.test_logicalnot_1d[False-True]
 test_elementwise_ops.TestElementwiseOperations.test_logicalnot_1d[True-False]
 test_elementwise_ops.TestElementwiseOperations.test_logicalnot_2d
 test_gathernd.TestGatherNDOperations.test_gather_nd
+test_mnist_training.TestMnistTraining.test_mnist_training[adam]
+test_mnist_training.TestMnistTraining.test_mnist_training[sgd]
+test_mnist_training.TestMnistTraining.test_mnist_training[momentum]
 test_pad.TestPadOperations.test_pad1
 test_pad.TestPadOperations.test_pad2
 test_pad.TestPadOperations.test_pad3


### PR DESCRIPTION
There is no `ops::Select` any more. Upgrade the select translation to use [SelectV2](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/select-v2).