### PR TITLE
Fix Pad op translation

### DIFF
--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2265,25 +2265,24 @@ static Status TranslatePadOp(const Node* op,
   }
 
   // Set pads_begin & pads_end (from the pad_val_op)
-  shared_ptr<opset::Constant> pads_begin_node, pads_end_node;
   std::vector<int64> paddings;
   TF_RETURN_IF_ERROR(GetStaticInputVector(op, 1, static_input_map, &paddings));
-  NGRAPH_VLOG(6) << op->name() << " pads {" << ng::join(paddings) << "}";
+  NGRAPH_VLOG(3) << op->name() << " pads {" << ng::join(paddings) << "}";
   if (paddings.size() % 2 != 0) {
     return errors::InvalidArgument(
         "Constant node for paddings does not have an even number of "
         "elements");
   }
-  ng::CoordinateDiff pad_begin(paddings.size() / 2);
-  ng::CoordinateDiff pad_end(paddings.size() / 2);
+  std::vector<int64> pad_begin(paddings.size() / 2);
+  std::vector<int64> pad_end(paddings.size() / 2);
   for (size_t i = 0; i < paddings.size() / 2; i++) {
     pad_begin[i] = paddings[2 * i];
     pad_end[i] = paddings[2 * i + 1];
   }
-  pads_begin_node = make_shared<opset::Constant>(
-      ng::element::i64, ng::Shape{pad_begin.size()}, pad_begin);
-  pads_end_node = make_shared<opset::Constant>(
-      ng::element::i64, ng::Shape{pad_end.size()}, pad_end);
+  auto pads_begin_node = ConstructNgNode<opset::Constant>(
+      op->name(), ng::element::i64, ng::Shape{pad_begin.size()}, pad_begin);
+  auto pads_end_node = ConstructNgNode<opset::Constant>(
+      op->name(), ng::element::i64, ng::Shape{pad_end.size()}, pad_end);
 
   // Create final Op
   result_pad_op =


### PR DESCRIPTION
* Use helper `ConstructNgNode` for constructing nodes in the Pad translation
* Use `vector<int64>` to represent paddings as nGraph can internally convert to CoordinateDiff if necessary