### PR TITLE
Revert "Eliminate use of pattern label for Concat in transpose-sinking"

### DIFF
--- a/ngraph_bridge/pass/transpose_sinking.cc
+++ b/ngraph_bridge/pass/transpose_sinking.cc
@@ -425,8 +425,9 @@ static void sink_concat(shared_ptr<opset::Concat> n, TransposeMap& reorders,
   auto new_concat = make_shared<opset::Concat>(new_args, new_axis);
   // put back the original arguments
   for (size_t i = 0; i < new_concat->get_input_size(); i++) {
-    ngraph::replace_node(new_args.at(i),
-                         n->input_value(i).get_node_shared_ptr());
+    NGRAPH_VLOG(4) << "Replacing " << new_concat->get_name() << " input " << i
+                   << " with " << n->get_name() << " input " << i;
+    new_concat->input(i).replace_source_output(n->input_value(i));
   }
   NGRAPH_VLOG(4) << "Replacing " << n->get_name() << " with "
                  << new_concat->get_name();

--- a/ngraph_bridge/pass/transpose_sinking.cc
+++ b/ngraph_bridge/pass/transpose_sinking.cc
@@ -389,6 +389,17 @@ static void sink_concat(shared_ptr<opset::Concat> n, TransposeMap& reorders,
   auto arg_transpose_order = ngraph::as_type_ptr<opset::Constant>(
       arg_transpose->input_value(1).get_node_shared_ptr());
   auto order = arg_transpose_order->get_axis_vector_val();
+  // we need the correct input shape to produce the right output shape
+  // we are going to create a label of the right input shape,
+  // so a new concat will have the right shape
+  auto def_order = ngraph::get_permutation_to_default_order(order);
+  auto input_shape =
+      ngraph::apply_permutation(arg_transpose->get_shape(), def_order);
+  auto dummy_correct_shape = make_shared<ngraph::pattern::op::Label>(
+      arg_transpose->get_element_type(), input_shape);
+
+  ngraph::NodeVector new_args;
+  new_args.push_back(dummy_correct_shape);
 
   for (size_t i = 1; i < n->get_input_size(); i++) {
     auto iarg = n->input_value(i);
@@ -402,10 +413,21 @@ static void sink_concat(shared_ptr<opset::Concat> n, TransposeMap& reorders,
       materialize_shapes(n, reorders, transposes_to_delete, reuse_map);
       return;
     }
+
+    auto iinput_shape =
+        ngraph::apply_permutation(iarg_transpose->get_shape(), def_order);
+    auto idummy_correct_shape = make_shared<ngraph::pattern::op::Label>(
+        iarg_transpose->get_element_type(), iinput_shape);
+    new_args.push_back(idummy_correct_shape);
   }
 
   auto new_axis = order.at(n->get_concatenation_axis());
-  auto new_concat = make_shared<opset::Concat>(n->input_values(), new_axis);
+  auto new_concat = make_shared<opset::Concat>(new_args, new_axis);
+  // put back the original arguments
+  for (size_t i = 0; i < new_concat->get_input_size(); i++) {
+    ngraph::replace_node(new_args.at(i),
+                         n->input_value(i).get_node_shared_ptr());
+  }
   NGRAPH_VLOG(4) << "Replacing " << n->get_name() << " with "
                  << new_concat->get_name();
   ngraph::replace_node(n, new_concat);


### PR DESCRIPTION
In some cases where a transpose is sunk through a Concat op, the shapes of the input arguments need to be transposed. In such cases, pattern labels are necessary to create dummy shapes for the new Concat op with transposed inputs.

* This reverts commit 8f95c9bd97ac08cbdd733c14f3e3c7aee2de9105.
* Also added a test case where dummy shapes are required in "concat sinking"
* Fixed a bug in pattern labels where the inputs to Concat come from a multi-output node such as a Split