### PR TITLE
Remove static linking build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,20 +132,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=${NGRAPH_TF_CXX11_ABI}")
 endif()
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    set(LIBNGRAPH "libngraph.a")
-    set(LIBCPU_BACKEND_A "libcpu_backend.a")
-    set(LIBINTERPRETER_BACKEND_A "libinterpreter_backend.a")
-else()
-    set(LIBNGRAPH "libngraph.so")
-endif()
-
-# TODO[Sindhu]
-# Should make static library changes for APPLE 
-# after Ngraph makes required changes for Mac build
-
 if(APPLE)
     set(LIBNGRAPH "libngraph.dylib")
+else()
+    set(LIBNGRAPH "libngraph.so")
 endif(APPLE)
 
 # Build options
@@ -153,7 +143,6 @@ option(USE_PRE_BUILT_NGRAPH "Use pre-built nGraph located in NGRAPH_ARTIFACTS_DI
 option(NGRAPH_ARTIFACTS_DIR "Where would nGraph be installed after build" FALSE)
 option(UNIT_TEST_ENABLE "Control the building of unit tests" FALSE)
 option(UNIT_TEST_TF_CC_DIR "Location where TensorFlow CC library is located" FALSE)
-option(NGRAPH_BRIDGE_STATIC_LIB_ENABLE "Enable build nGraph bridge static library" FALSE)
 option(ENABLE_OPENVINO "Build OpenVINO backend" FALSE)
 option(USE_PREBUILT_OPENVINO "Use prebuilt OpenVINO located in OPENVINO_ARTIFACTS_DIR" FALSE)
 option(OPENVINO_ARTIFACTS_DIR "Where would OpenVINO be installed after build" FALSE)
@@ -271,10 +260,6 @@ if (NOT USE_PRE_BUILT_NGRAPH)
 endif()
 set(NGRAPH_INSTALL_DIR ${NGRAPH_ARTIFACTS_DIR})
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    add_definitions(-DNGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-endif()
-
 if(OS_VERSION STREQUAL "\"centos\"")
     set(LIB "lib64")
 else()
@@ -282,65 +267,12 @@ else()
 endif()
 
 set(NGRAPH_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/${LIB}/${LIBNGRAPH})
-
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    set(CPU_BACKEND_IMPORTED_LOCATION_STATIC ${NGRAPH_INSTALL_DIR}/${LIB}/${LIBCPU_BACKEND_A})
-    set(INTERPRETER_BACKEND_IMPORTED_LOCATION_STATIC ${NGRAPH_INSTALL_DIR}/${LIB}/${LIBINTERPRETER_BACKEND_A})
-    set(LIB_DNNL_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/${LIB}/libdnnl.so)
-    set(LIB_MKLML_INTEL_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/${LIB}/libmklml_intel.so)
-    set(LIB_IOMP5_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/${LIB}/libiomp5.so)
-
-    add_library(ngraph_lib STATIC IMPORTED)
-    set_target_properties(
-        ngraph_lib
-        PROPERTIES IMPORTED_LOCATION
-        ${NGRAPH_IMPORTED_LOCATION}
-    )   
-
-    add_library(lib_cpu_backend_static STATIC IMPORTED)
-    set_target_properties(
-        lib_cpu_backend_static
-        PROPERTIES IMPORTED_LOCATION
-        ${CPU_BACKEND_IMPORTED_LOCATION_STATIC}
-    )
-
-    add_library(lib_interpreter_backend_static STATIC IMPORTED)
-    set_target_properties(
-        lib_interpreter_backend_static
-        PROPERTIES IMPORTED_LOCATION
-        ${INTERPRETER_BACKEND_IMPORTED_LOCATION_STATIC}
-    )
-
-    add_library(lib_dnnl SHARED IMPORTED)
-    set_target_properties(
-        lib_dnnl
-        PROPERTIES IMPORTED_LOCATION
-        ${LIB_DNNL_IMPORTED_LOCATION}
-    )
-
-    add_library(lib_mklml_intel SHARED IMPORTED)
-    set_target_properties(
-        lib_mklml_intel
-        PROPERTIES IMPORTED_LOCATION
-        ${LIB_MKLML_INTEL_IMPORTED_LOCATION}
-        IMPORTED_NO_SONAME 1
-    )
-
-    add_library(lib_iomp5 SHARED IMPORTED)
-    set_target_properties(
-        lib_iomp5
-        PROPERTIES IMPORTED_LOCATION
-        ${LIB_IOMP5_IMPORTED_LOCATION}
-    )
-
-else()
-    add_library(ngraph_lib SHARED IMPORTED)
-    set_target_properties(
-        ngraph_lib
-        PROPERTIES IMPORTED_LOCATION
-        ${NGRAPH_IMPORTED_LOCATION}
-    )
-endif()
+add_library(ngraph_lib SHARED IMPORTED)
+set_target_properties(
+    ngraph_lib
+    PROPERTIES IMPORTED_LOCATION
+    ${NGRAPH_IMPORTED_LOCATION}
+)
 
 add_dependencies(ngraph_lib ext_ngraph)
 

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -140,11 +140,6 @@ def main():
         default='')
 
     parser.add_argument(
-        '--use_ngraph_staticlibs',
-        help="Builds and links ngraph statically\n",
-        action="store_true")
-
-    parser.add_argument(
         '--disable_cpp_api',
         help="Disables C++ API, unit tests and examples\n",
         action="store_true")
@@ -394,15 +389,6 @@ def main():
                 "-DNGRAPH_TUNE_ARCH=" + target_arch, "-DNGRAPH_TBB_ENABLE=FALSE"
             ]
 
-            if arguments.use_ngraph_staticlibs:
-                ngraph_cmake_flags.extend(["-DNGRAPH_STATIC_LIB_ENABLE=TRUE"])
-                ngraph_cmake_flags.extend(
-                    ["-DNGRAPH_CPU_STATIC_LIB_ENABLE=TRUE"])
-                ngraph_cmake_flags.extend(
-                    ["-DNGRAPH_INTERPRETER_STATIC_LIB_ENABLE=TRUE"])
-                ngraph_cmake_flags.extend(
-                    ["-DNGRAPH_DYNAMIC_COMPONENTS_ENABLE=OFF"])
-
             if arguments.debug_build:
                 ngraph_cmake_flags.extend(["-DCMAKE_BUILD_TYPE=Debug"])
 
@@ -446,9 +432,6 @@ def main():
                 "-DNGRAPH_ARTIFACTS_DIR=" + os.path.abspath(
                     arguments.use_prebuilt_ngraph)
             ])
-
-    if (arguments.use_ngraph_staticlibs):
-        ngraph_tf_cmake_flags.extend(["-DNGRAPH_BRIDGE_STATIC_LIB_ENABLE=TRUE"])
 
     if (arguments.debug_build):
         ngraph_tf_cmake_flags.extend(["-DCMAKE_BUILD_TYPE=Debug"])

--- a/examples/cpp/inference/CMakeLists.txt
+++ b/examples/cpp/inference/CMakeLists.txt
@@ -61,40 +61,15 @@ if (APPLE)
     add_definitions(-DTEST_SINGLE_INSTANCE)
 endif()
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    add_definitions(-DNGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-endif()
-
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    target_link_libraries(
-        ${APP_NAME} 
-        -Wl,--whole-archive
-            ngraph_bridge_static
-        -Wl,--no-whole-archive
-        ngraph_lib
-        lib_cpu_backend_static
-        lib_interpreter_backend_static 
-        ngraph_lib
-        dl
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        absl_synchronization
-        lib_dnnl
-        lib_iomp5
-        lib_mklml_intel
-    )
-else()
-    target_link_libraries(
-        ${APP_NAME}
-        ngraph_bridge
-        ngraph_lib
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        absl_synchronization
-    )
-endif()
+target_link_libraries(
+    ${APP_NAME}
+    ngraph_bridge
+    ngraph_lib
+    pthread
+    ${TensorFlow_FRAMEWORK_LIBRARY}
+    tensorflow_cc_lib
+    absl_synchronization
+)
 
 if (ENABLE_OPENVINO)
     target_link_libraries(${APP_NAME} ${InferenceEngine_LIBRARIES} ${TBB_IMPORTED_TARGETS})
@@ -105,36 +80,15 @@ add_executable(
     ${APP_NAME_MULTI} ${SRC} infer_multiple_networks.cc
 )
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    target_link_libraries(
-        ${APP_NAME_MULTI} 
-        -Wl,--whole-archive
-            ngraph_bridge_static
-        -Wl,--no-whole-archive
-        ngraph_lib
-        lib_cpu_backend_static
-        lib_interpreter_backend_static 
-        ngraph_lib
-        dl
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        absl_synchronization
-        lib_dnnl
-        lib_iomp5
-        lib_mklml_intel
-    )
-else()
-    target_link_libraries(
-        ${APP_NAME_MULTI}
-        ngraph_bridge
-        ngraph_lib
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        absl_synchronization
-    )
-endif()
+target_link_libraries(
+    ${APP_NAME_MULTI}
+    ngraph_bridge
+    ngraph_lib
+    pthread
+    ${TensorFlow_FRAMEWORK_LIBRARY}
+    tensorflow_cc_lib
+    absl_synchronization
+)
 
 if (ENABLE_OPENVINO)
     target_link_libraries(${APP_NAME_MULTI} ${InferenceEngine_LIBRARIES} ${TBB_IMPORTED_TARGETS})

--- a/examples/cpp/inference/infer_multiple_networks.cc
+++ b/examples/cpp/inference/infer_multiple_networks.cc
@@ -161,13 +161,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-// Register cpu backend for static linking
-// [TODO]: Revisit this to see if we can remove registering here and register
-// only in BackendManager.
-#if defined(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-  ngraph_register_cpu_backend();
-#endif
-
   const char* backend = "CPU";
   if (SetNGraphBackend(backend) != tf::Status::OK()) {
     std::cout << "Error: Cannot set the backend: " << backend << std::endl;

--- a/examples/cpp/inference/infer_single_network.cc
+++ b/examples/cpp/inference/infer_single_network.cc
@@ -155,11 +155,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-// Register cpu backend for static linking
-#if defined(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-  ngraph_register_cpu_backend();
-#endif
-
   const char* backend = "CPU";
   if (SetNGraphBackend(backend) != tf::Status::OK()) {
     std::cout << "Error: Cannot set the backend: " << backend << std::endl;

--- a/ngraph_bridge/CMakeLists.txt
+++ b/ngraph_bridge/CMakeLists.txt
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 set(LIB_NAME ngraph_bridge)
-set(LIB_NAME_STATIC ngraph_bridge_static)
 
 include_directories(${TensorFlow_INCLUDE_DIR})
 include_directories(${TensorFlow_INCLUDE_DIR}/external/nsync/public)
@@ -52,10 +51,6 @@ set(SRC
    version.cc
 )
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    add_definitions(-DNGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-endif()
-
 if(NGRAPH_TF_USE_GRAPPLER_OPTIMIZER)            
     list(REMOVE_ITEM SRC ngraph_rewrite_pass.cc)
     list(APPEND SRC grappler/ngraph_optimizer.cc)
@@ -77,39 +72,15 @@ message(STATUS "ENABLE_OPENVINO: ${ENABLE_OPENVINO}")
 
 add_library(${LIB_NAME} SHARED ${SRC})
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    target_link_libraries(
-            ${LIB_NAME}
-            ngraph_logger 
-            ${TensorFlow_FRAMEWORK_LIBRARY} 
-            ngraph_lib
-            lib_cpu_backend_static
-            lib_interpreter_backend_static
-            ngraph_lib
-            dl
-            pthread
-            absl_algorithm
-            absl_container
-            absl_strings
-            lib_mklml_intel
-            lib_dnnl
-            lib_iomp5
-        )
-
-        target_compile_definitions(
-        ${LIB_NAME} PRIVATE 
-        "NGRAPH_BRIDGE_STATIC_LIB_ENABLE")
-else()
-    target_link_libraries(
-            ${LIB_NAME}
-            ngraph_logger 
-            ${TensorFlow_FRAMEWORK_LIBRARY} 
-            ngraph_lib
-            absl_algorithm
-            absl_container
-            absl_strings
-        )
-endif()
+target_link_libraries(
+        ${LIB_NAME}
+        ngraph_logger 
+        ${TensorFlow_FRAMEWORK_LIBRARY} 
+        ngraph_lib
+        absl_algorithm
+        absl_container
+        absl_strings
+    )
 
 if (ENABLE_OPENVINO)
     target_link_libraries(${LIB_NAME} ${InferenceEngine_LIBRARIES})
@@ -121,35 +92,6 @@ target_compile_definitions(
 )
 
 target_include_directories(${LIB_NAME} PUBLIC "${NGRAPH_INSTALL_DIR}/include")
-
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    add_library(${LIB_NAME_STATIC} STATIC ${SRC})
-    target_link_libraries(
-        ${LIB_NAME_STATIC}
-        ngraph_logger
-        ${TensorFlow_FRAMEWORK_LIBRARY} 
-        lib_cpu_backend_static
-        lib_interpreter_backend_static 
-        ngraph_lib
-        dl
-        absl_algorithm
-        absl_container
-        absl_strings
-        lib_dnnl
-        lib_iomp5
-        lib_mklml_intel
-    )
-    target_compile_definitions(
-    ${LIB_NAME_STATIC} PRIVATE 
-    "NGRAPH_BRIDGE_STATIC_LIB_ENABLE")
-    
-    target_compile_definitions( 
-    ${LIB_NAME_STATIC} PRIVATE
-    _GLIBCXX_USE_CXX11_ABI=${TensorFlow_CXX_ABI}
-    )
-
-    target_include_directories(${LIB_NAME_STATIC} PUBLIC "${NGRAPH_INSTALL_DIR}/include")
-endif()
 
 #------------------------------------------------------------------------------
 #installation 
@@ -167,11 +109,6 @@ else()
 endif()
 
 message(STATUS "NGTF_INSTALL_LIB_DIR: ${NGTF_INSTALL_LIB_DIR}")
-
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    # First install the libngraph_bridge_static.a and headers
-    install(TARGETS ${LIB_NAME_STATIC} DESTINATION "${NGTF_INSTALL_LIB_DIR}")
-endif()
 
 # First install the libngraph_bridge.so and headers
 install(TARGETS ${LIB_NAME} DESTINATION "${NGTF_INSTALL_LIB_DIR}")  

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -79,12 +79,6 @@ Status BackendManager::GetBackendName(string& backend_name) {
 
 Status BackendManager::CreateBackend(shared_ptr<Backend>& backend,
                                      string& backend_name) {
-// Register backends for static linking
-#if defined(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-  ngraph_register_cpu_backend();
-  ngraph_register_interpreter_backend();
-#endif
-
   const char* env = std::getenv("NGRAPH_TF_BACKEND");
   if (env != nullptr && strlen(env) > 0) {
     backend_name = string(env);

--- a/ngraph_bridge/ngraph_backend_manager.h
+++ b/ngraph_bridge/ngraph_backend_manager.h
@@ -68,10 +68,5 @@ class BackendManager {
 }  // namespace ngraph_bridge
 }  // namespace tensorflow
 
-#if defined(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-extern "C" void ngraph_register_cpu_backend();
-extern "C" void ngraph_register_interpreter_backend();
-#endif
-
 #endif
 // NGRAPH_TF_BRIDGE_BACKEND_MANAGER_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,43 +151,17 @@ if (APPLE)
     set(NGRAPH_TF_CXX11_ABI 0)
 endif()
 
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    add_definitions(-DNGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-endif()
-
-if(NGRAPH_BRIDGE_STATIC_LIB_ENABLE)
-    target_link_libraries(gtest_ngtf
-        -Wl,--whole-archive
-            ngraph_bridge_static
-        -Wl,--no-whole-archive
-        ngraph_lib
-        lib_cpu_backend_static
-        lib_interpreter_backend_static 
-        ngraph_lib
-        dl
-        libgtest
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        tensorflow_ops_testutil
-        absl_synchronization
-        lib_dnnl
-        lib_iomp5
-        lib_mklml_intel
-    )
-else()
-    target_link_libraries(
-        gtest_ngtf
-        ngraph_bridge
-        ngraph_lib
-        libgtest
-        pthread
-        ${TensorFlow_FRAMEWORK_LIBRARY}
-        tensorflow_cc_lib
-        tensorflow_ops_testutil
-        absl_synchronization
-    )
-endif()
+target_link_libraries(
+    gtest_ngtf
+    ngraph_bridge
+    ngraph_lib
+    libgtest
+    pthread
+    ${TensorFlow_FRAMEWORK_LIBRARY}
+    tensorflow_cc_lib
+    tensorflow_ops_testutil
+    absl_synchronization
+)
 
 if (ENABLE_OPENVINO)
     target_link_libraries(gtest_ngtf ${InferenceEngine_LIBRARIES} ${TBB_IMPORTED_TARGETS})


### PR DESCRIPTION
There is currently no support to build statically against OpenVINO
libraries. Remove build option to build and link the bridge statically.