### PR TITLE
Add build option to build with intel-tf from source

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -55,6 +55,7 @@ def main():
     # Component versions
     ngraph_version = "94456090176ad6abda633b496b89cc16157ed4b0"  #add codegen support to cpu backend (#4679) ,May 26
     tf_version = "v2.2.0"
+    use_intel_tf = False
 
     # Command line parser options
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
@@ -98,6 +99,11 @@ def main():
         default='',
         nargs='?',
         action="store")
+
+    parser.add_argument(
+        '--use_intel_tensorflow',
+        help="Build using Intel TensorFlow.",
+        action="store_true")
 
     parser.add_argument(
         '--use_prebuilt_ngraph',
@@ -311,13 +317,16 @@ def main():
             tf_src_dir = os.path.join(os.getcwd(), "tensorflow")
             print("TF_SRC_DIR: ", tf_src_dir)
 
+            if arguments.use_intel_tensorflow != '':
+                use_intel_tf = True
+
             # Build TensorFlow
             build_tensorflow(tf_version, "tensorflow", artifacts_location,
-                             target_arch, verbosity)
+                             target_arch, verbosity, use_intel_tf)
 
             # Now build the libtensorflow_cc.so - the C++ library
             build_tensorflow_cc(tf_version, tf_src_dir, artifacts_location,
-                                target_arch, verbosity)
+                                target_arch, verbosity, use_intel_tf)
 
             # Install tensorflow to our own virtual env
             # Note that if gcc 7.3 is used for building TensorFlow this flag

--- a/build_tf.py
+++ b/build_tf.py
@@ -41,6 +41,10 @@ def main():
         help=
         "Architecture flag to use (e.g., haswell, core-avx2 etc. Default \'native\'\n",
         default="native")
+    parser.add_argument(
+        '--use_intel_tensorflow',
+        help="Build using Intel TensorFlow.",
+        action="store_true")
     arguments = parser.parse_args()
 
     if not os.path.isdir(arguments.output_dir):
@@ -66,13 +70,17 @@ def main():
         call(["git", "pull"])
         os.chdir(pwd)
 
+    use_intel_tf = False
+    if arguments.use_intel_tensorflow != '':
+        use_intel_tf = True
+
     # Build TensorFlow
     build_tensorflow(arguments.tf_version, "tensorflow", 'artifacts',
-                     arguments.target_arch, False)
+                     arguments.target_arch, False, use_intel_tf)
 
     # Build TensorFlow C++ Library
     build_tensorflow_cc(arguments.tf_version, "tensorflow", 'artifacts',
-                        arguments.target_arch, False)
+                        arguments.target_arch, False, use_intel_tf)
 
     pwd = os.getcwd()
     artifacts_dir = os.path.join(pwd, 'artifacts/tensorflow')

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -192,6 +192,7 @@ def build_tensorflow(tf_version,
                      artifacts_dir,
                      target_arch,
                      verbosity,
+                     use_intel_tf,
                      target=""):
     # In order to build TensorFlow, we need to be in the virtual environment
     pwd = os.getcwd()
@@ -238,6 +239,11 @@ def build_tensorflow(tf_version,
         "--config=nohdfs",
         "--config=nonccl",
     ]
+    if use_intel_tf:
+        print("Building Intel-Tensorflow")
+        cmd.extend([
+            "--config=mkl",
+        ])
     # Build the python package
     if (tf_version.startswith("v2.") or tf_version.startswith("2.")):
         cmd.extend([
@@ -280,6 +286,7 @@ def build_tensorflow_cc(tf_version,
                         artifacts_dir,
                         target_arch,
                         verbosity,
+                        use_intel_tf,
                         tf_prebuilt=None):
     lib = "libtensorflow_cc.so.2"
     if (tf_version.startswith("v2.") or tf_version.startswith("2.")):
@@ -293,6 +300,7 @@ def build_tensorflow_cc(tf_version,
         artifacts_dir,
         target_arch,
         verbosity,
+        use_intel_tf,
         target="//tensorflow:" + tf_cc_lib_name +
         " //tensorflow/core/kernels:ops_testutil")
 


### PR DESCRIPTION
The flag '--use_intel_tensorflow' can now be specified to
* build_tf.py to build Intel TF
* build_ngtf.py to build the bridge against Intel TF