### PR TITLE
Eliminate "static inputs" for translations

### DIFF
--- a/ngraph_bridge/ie_executable.cc
+++ b/ngraph_bridge/ie_executable.cc
@@ -48,7 +48,11 @@ IE_Executable::IE_Executable(shared_ptr<Function> func, string device)
   bool trivial_fn = true;
   for (auto result : func->get_results()) {
     auto parent = result->input_value(0).get_node_shared_ptr();
-    auto& shape = result->get_shape();
+    ngraph::Shape shape = {1};
+    if (result->get_output_partial_shape(0).is_static()) {
+      shape = result->get_shape();
+    }
+
     trivial_fn &= ngraph::is_type<opset::Parameter>(parent) ||
                   ngraph::is_type<opset::Constant>(parent) ||
                   count(shape.begin(), shape.end(), 0);

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -195,34 +195,16 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
 
   if (!initialized) {
     // Set Additional Attributes (if any)
-    set_attributes_map["Any"] = SetStaticInputs({1});
-    set_attributes_map["All"] = SetStaticInputs({1});
     set_attributes_map["ArgMax"] = SetStaticInputs({1});
     set_attributes_map["ArgMin"] = SetStaticInputs({1});
     set_attributes_map["ConcatV2"] = SetStaticInputs({-1});
     set_attributes_map["Conv2DBackpropInput"] = SetStaticInputs({0});
     set_attributes_map["ExpandDims"] = SetStaticInputs({1});
-    set_attributes_map["Fill"] = SetStaticInputs({0});
-    set_attributes_map["GatherV2"] = SetStaticInputs({2});
-    set_attributes_map["Max"] = SetStaticInputs({1});
-    set_attributes_map["Mean"] = SetStaticInputs({1});
-    set_attributes_map["Min"] = SetStaticInputs({1});
     set_attributes_map["MirrorPad"] = SetStaticInputs({1});
-    set_attributes_map["NonMaxSuppressionV4"] = SetStaticInputs({2, 3, 4});
-    set_attributes_map["OneHot"] = SetStaticInputs({1});
     set_attributes_map["Pad"] = SetStaticInputs({1});
     set_attributes_map["PadV2"] = SetStaticInputs({1, 2});
-    set_attributes_map["Prod"] = SetStaticInputs({1});
-    set_attributes_map["Reshape"] = SetStaticInputs({1});
-    set_attributes_map["Shape"] = SetStaticInputs({0});
     set_attributes_map["Slice"] = SetStaticInputs({1, 2});
-    set_attributes_map["Split"] = SetStaticInputs({0});
     set_attributes_map["SplitV"] = SetStaticInputs({1, 2});
-    set_attributes_map["StridedSlice"] = SetStaticInputs({1, 2, 3});
-    set_attributes_map["Sum"] = SetStaticInputs({1});
-    set_attributes_map["TopKV2"] = SetStaticInputs({1});
-    set_attributes_map["Tile"] = SetStaticInputs({1});
-    set_attributes_map["Transpose"] = SetStaticInputs({1});
     initialized = true;
   }
   return set_attributes_map;
@@ -531,7 +513,7 @@ const TypeConstraintMap& GetTypeConstraintMap() {
     type_constraint_map["SquaredDifference"]["T"] = NGraphDTypes();
     type_constraint_map["Squeeze"]["T"] = NGraphDTypes();
     type_constraint_map["StridedSlice"]["T"] = NGraphDTypes();
-    type_constraint_map["StridedSlice"]["Index"] = NGraphIndexDTypes();
+    type_constraint_map["StridedSlice"]["Index"] = { DT_INT64 };
     type_constraint_map["Sub"]["T"] = NGraphNumericDTypes();
     type_constraint_map["Sum"]["T"] = NGraphNumericDTypes();
     type_constraint_map["Sum"]["Tidx"] = NGraphIndexDTypes();

--- a/test/tests_linux_cpu.txt
+++ b/test/tests_linux_cpu.txt
@@ -48,7 +48,6 @@ MathOps.Pow0D1D
 # Const layer Squeeze/Constant_3544 has incorrect dimensions in the output data 0
 MathOps.SqueezeNoAttributes
 
-
 # Const/Const/Constant_1260 has zero dimension which is not allowed
 NNOps.L2Loss
 
@@ -59,8 +58,3 @@ ArrayOps.Shape3D
 # zero dimension
 ArrayOps.SplitVZeroSizeSplit
 ArrayOps.SplitVZeroSizeNegSplit
-
-MathOps.FloorModNegFloat #Floor_mod supports only I32 precision of inputs
-
-
-

--- a/tools/test_utils.py
+++ b/tools/test_utils.py
@@ -70,7 +70,8 @@ class TestEnv:
             # test manifest files are named like this:
             # tests_${PLATFORM}_${NGRAPH_TF_BACKEND}.txt
             return 'tests_' + TestEnv.PLATFORM().lower(
-            ) + '_' + TestEnv.BACKEND().lower() + '.txt'
+            ) + '_' + TestEnv.BACKEND(
+            ).lower() + '.txt'
 
     @staticmethod
     def PLATFORM():

--- a/tools/test_utils.py
+++ b/tools/test_utils.py
@@ -70,8 +70,7 @@ class TestEnv:
             # test manifest files are named like this:
             # tests_${PLATFORM}_${NGRAPH_TF_BACKEND}.txt
             return 'tests_' + TestEnv.PLATFORM().lower(
-            ) + '_' + TestEnv.BACKEND(
-            ).lower() + '.txt'
+            ) + '_' + TestEnv.BACKEND().lower() + '.txt'
 
     @staticmethod
     def PLATFORM():


### PR DESCRIPTION
This PR removes the "static input" constraint (the constraint that one of the inputs be statically known at op construction/translation time) for several translations.