### PR TITLE
Support dynamic output tensors in the backend

### DIFF
--- a/ngraph_bridge/executable.cc
+++ b/ngraph_bridge/executable.cc
@@ -123,7 +123,7 @@ bool Executable::call(const vector<shared_ptr<runtime::Tensor>>& inputs,
                       vector<shared_ptr<runtime::Tensor>>& outputs) {
   if (m_trivial_fn) {
     NGRAPH_VLOG(2) << "Calling trivial IE function with inputs="
-                   << inputs.size();
+                   << inputs.size() << " outputs=" << outputs.size();
     return call_trivial(inputs, outputs);
   }
 

--- a/ngraph_bridge/executable.h
+++ b/ngraph_bridge/executable.h
@@ -34,16 +34,17 @@ class Executable {
  public:
   Executable(shared_ptr<ngraph::Function> func, string device);
   ~Executable() {}
-  bool call(const vector<shared_ptr<ngraph::runtime::Tensor>>& outputs,
-            const vector<shared_ptr<ngraph::runtime::Tensor>>& inputs);
+  bool call(const vector<shared_ptr<ngraph::runtime::Tensor>>& inputs,
+            vector<shared_ptr<ngraph::runtime::Tensor>>& outputs);
 
   const ngraph::ResultVector& get_results() {
     return m_function->get_results();
   };
 
  private:
-  bool call_trivial(const vector<shared_ptr<ngraph::runtime::Tensor>>& outputs,
-                    const vector<shared_ptr<ngraph::runtime::Tensor>>& inputs);
+  bool call_trivial(const vector<shared_ptr<ngraph::runtime::Tensor>>& inputs,
+                    vector<shared_ptr<ngraph::runtime::Tensor>>& outputs);
+
   InferenceEngine::CNNNetwork m_network;
   InferenceEngine::InferRequest m_infer_req;
   string m_device;

--- a/ngraph_bridge/ie_tensor.h
+++ b/ngraph_bridge/ie_tensor.h
@@ -58,12 +58,6 @@ class IETensorBuffer : public TensorBuffer {
         size_(tensor->get_size_in_bytes()),
         tensor_(tensor) {}
 
-  // ~IETensorBuffer() override {
-  //   if (data()) {
-  //     delete tensor_;
-  //   }
-  // }
-
   size_t size() const override { return size_; }
 
   TensorBuffer* root_buffer() override { return this; }

--- a/ngraph_bridge/ie_tensor.h
+++ b/ngraph_bridge/ie_tensor.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include "tensorflow/core/framework/allocation_description.pb.h"
+#include "tensorflow/core/framework/tensor.h"
+
 #include <ie_core.hpp>
 #include "ngraph/ngraph.hpp"
 
@@ -30,19 +33,48 @@ class IETensor : public ngraph::runtime::Tensor {
            const ngraph::PartialShape& shape);
   IETensor(const ngraph::element::Type& element_type,
            const ngraph::Shape& shape, void* memory_pointer);
+  IETensor(InferenceEngine::Blob::Ptr blob);
   ~IETensor() override;
 
   void write(const void* src, size_t bytes) override;
   void read(void* dst, size_t bytes) const override;
 
   const void* get_data_ptr() const;
-  InferenceEngine::MemoryBlob::Ptr get_blob() { return m_blob; }
+  InferenceEngine::Blob::Ptr get_blob() { return m_blob; }
 
  private:
   IETensor(const IETensor&) = delete;
   IETensor(IETensor&&) = delete;
   IETensor& operator=(const IETensor&) = delete;
-  InferenceEngine::MemoryBlob::Ptr m_blob;
+  InferenceEngine::Blob::Ptr m_blob;
+};
+
+// A simple TensorBuffer implementation that allows us to create Tensors that
+// take ownership of pre-allocated memory.
+class IETensorBuffer : public TensorBuffer {
+ public:
+  IETensorBuffer(std::shared_ptr<IETensor> tensor)
+      : TensorBuffer(const_cast<void*>(tensor->get_data_ptr())),
+        size_(tensor->get_size_in_bytes()),
+        tensor_(tensor) {}
+
+  // ~IETensorBuffer() override {
+  //   if (data()) {
+  //     delete tensor_;
+  //   }
+  // }
+
+  size_t size() const override { return size_; }
+
+  TensorBuffer* root_buffer() override { return this; }
+
+  void FillAllocationDescription(AllocationDescription* proto) const override {
+    proto->set_allocated_bytes(size_);
+  }
+
+ private:
+  size_t size_;
+  std::shared_ptr<IETensor> tensor_;
 };
 }
 }

--- a/ngraph_bridge/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/ngraph_encapsulate_op.cc
@@ -270,16 +270,20 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     auto ng_shape = ng_output->get_shape();
 
     // Create the TF output tensor
-    vector<int64> dims;
+    TensorShape tf_shape;
     for (auto dim : ng_shape) {
-      dims.push_back(dim);
+      tf_shape.AddDim(dim);
     }
-    TensorShape tf_shape(dims);
-    IETensorBuffer* tf_buffer =
-        new IETensorBuffer(static_pointer_cast<IETensor>(ng_output));
-    Tensor tf_tensor(ctx->expected_output_dtype(i), TensorShape(dims),
-                     tf_buffer);
-    ctx->set_output(i, tf_tensor);
+
+    // Zero-copy IE tensor to TF
+    // IETensorBuffer* tf_buffer =
+    //     new IETensorBuffer(static_pointer_cast<IETensor>(ng_output));
+    // Tensor tf_tensor(ctx->expected_output_dtype(i), tf_shape, tf_buffer);
+    // ctx->set_output(i, tf_tensor);
+
+    Tensor* tf_tensor;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(i, tf_shape, &tf_tensor));
+    ng_output->read(tf_tensor->data(), tf_tensor->AllocatedBytes());
   }
 
   long vm, rss;

--- a/test/python/tensorflow/tests_linux_cpu.txt
+++ b/test/python/tensorflow/tests_linux_cpu.txt
@@ -151,6 +151,7 @@ conv_ops_test.Conv2DTest.testInputGradientValidPaddingStrideThree
 conv_ops_test.Conv2DTest.testInputGradientValidPaddingStrideTwo
 slice_op_test.SliceTest.testSimple
 
+gather_op_test.GatherTest.testBadAxis
 gather_nd_op_test.GatherNdTest.testGradientsRank2Slices
 gather_nd_op_test.GatherNdTest.testGradientsRank2SlicesWithEmptySpace
 math_ops_test.AddNTest.testGrad

--- a/test/python/tensorflow/tests_linux_cpu.txt
+++ b/test/python/tensorflow/tests_linux_cpu.txt
@@ -151,7 +151,6 @@ conv_ops_test.Conv2DTest.testInputGradientValidPaddingStrideThree
 conv_ops_test.Conv2DTest.testInputGradientValidPaddingStrideTwo
 slice_op_test.SliceTest.testSimple
 
-gather_op_test.GatherTest.testBadAxis
 gather_nd_op_test.GatherNdTest.testGradientsRank2Slices
 gather_nd_op_test.GatherNdTest.testGradientsRank2SlicesWithEmptySpace
 math_ops_test.AddNTest.testGrad

--- a/test/test_math_ops.cpp
+++ b/test/test_math_ops.cpp
@@ -484,6 +484,10 @@ TEST_F(MathOpsSumFixture, FullSet) {
       }
     }
   }
+  // Add few more tests with axes-combos
+  TestWith({6, 2}, {0, 1}, false);
+  TestWith({6, 2}, {0, 1}, true);
+  TestWith({2, 4, 3}, {0, 1, 2}, false);
 }
 // END MathOpsSumFixture
 

--- a/test/test_math_ops.cpp
+++ b/test/test_math_ops.cpp
@@ -37,12 +37,9 @@
 #include "test/test_utilities.h"
 
 using namespace std;
-namespace ng = ngraph;
 
 namespace tensorflow {
-
 namespace ngraph_bridge {
-
 namespace testing {
 
 // Test(TestCaseName, TestName)
@@ -446,29 +443,22 @@ class MathOpsSumFixture : public ::testing::Test {
  protected:
   void SetUp() override {}
   void TearDown() override {}
-  void TestWith(std::vector<int> tshpvec, std::vector<int> axisvec,
+  void TestWith(std::vector<int64> shape, std::vector<int64> axis,
                 bool keep_dims) {
-    TensorShape tshp;
-    for (auto dim : tshpvec) {
-      tshp.AddDim(dim);
-    }
-    std::stringstream axisvec_ss;
-    std::copy(axisvec.begin(), axisvec.end(),
-              std::ostream_iterator<int>(axisvec_ss, ","));
-    std::cout << ">> Running test with: tensor-shape=" << tshp
-              << ", axis=" << axisvec_ss.str() << ", keep_dims=" << keep_dims
-              << endl;
+    std::cout << ">> Running test with: tensor shape=[" << ngraph::join(shape)
+              << "], axis=[" << ngraph::join(axis)
+              << "], keep_dims=" << keep_dims << std::endl;
     Scope root = Scope::NewRootScope();
-    auto keep_dims_attr = ops::Sum::Attrs().KeepDims(keep_dims);
 
     std::vector<int> vals = {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6,
                              1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6};
-    Tensor A(DT_INT32, TensorShape(tshp));
+    Tensor A(DT_INT32, TensorShape(shape));
     AssignInputValues<int>(A, vals);
 
-    Tensor B(DT_INT32, TensorShape({(int64)axisvec.size()}));
-    AssignInputValues<int>(B, axisvec);
+    Tensor B(DT_INT64, TensorShape({static_cast<int64>(axis.size())}));
+    AssignInputValues<int64>(B, axis);
 
+    auto keep_dims_attr = ops::Sum::Attrs().KeepDims(keep_dims);
     auto R = ops::Sum(root, A, B, keep_dims_attr);
     std::vector<Output> sess_run_fetchoutputs = {R};
     OpExecuter opexecuter(root, "Sum", sess_run_fetchoutputs);
@@ -483,25 +473,17 @@ TEST_F(MathOpsSumFixture, LimitedSet1) {
 }
 
 TEST_F(MathOpsSumFixture, FullSet) {
-  vector<vector<int>> tshapes = {{2, 3},         {2, 2, 3},    {6, 2},
-                                 {2, 4, 3},      {4, 3, 2, 1}, {1, 2, 3, 4},
-                                 {3, 1, 2, 4, 1}};
+  vector<vector<int64>> shapes = {{2, 3},         {2, 2, 3},    {6, 2},
+                                  {2, 4, 3},      {4, 3, 2, 1}, {1, 2, 3, 4},
+                                  {3, 1, 2, 4, 1}};
   vector<bool> v_keep_dims = {true, false};
-  for (auto tshp : tshapes) {
-    vector<vector<int>> vv_axis;
-    for (auto ax = 0; ax < tshp.size(); ax++) {
-      vv_axis.push_back({ax});
-    }
-    for (auto v_axis : vv_axis) {
+  for (auto shape : shapes) {
+    for (int64 i = 0; i < shape.size(); i++) {
       for (auto keep_dims : v_keep_dims) {
-        TestWith(tshp, v_axis, keep_dims);
+        TestWith(shape, {i}, keep_dims);
       }
     }
   }
-  // Add few more tests with axes-combos
-  TestWith({6, 2}, {0, 1}, false);
-  TestWith({6, 2}, {0, 1}, true);
-  TestWith({2, 4, 3}, {0, 1, 2}, false);
 }
 // END MathOpsSumFixture
 

--- a/test/test_ngraph_exec.cpp
+++ b/test/test_ngraph_exec.cpp
@@ -173,19 +173,10 @@ TEST_F(NGraphExecTest, Axpy) {
   auto t_y = backend->create_tensor(ng::element::f32, ng_shape_y);
   t_y->write(&v_x, sizeof(v_x));
 
-  // Allocate tensor for the result(s)
-  vector<shared_ptr<ng::runtime::Tensor>> outputs;
-  for (size_t i = 0; i < ng_function->get_output_size(); i++) {
-    auto shape = ng_function->get_output_shape(i);
-    auto elem_type = ng_function->get_output_element_type(i);
-    auto t_result = backend->create_tensor(elem_type, shape);
-    outputs.push_back(t_result);
-  }
-
   // Execute the nGraph function.
-  cout << "Calling nGraph function\n";
   auto exec = backend->compile(ng_function);
-  exec->call(outputs, {t_x, t_y});
+  vector<shared_ptr<ng::runtime::Tensor>> outputs;
+  exec->call({t_x, t_y}, outputs);
 
   for (size_t i = 0; i < ng_function->get_output_size(); i++) {
     DumpNGTensor<float>(cout, ng_function->get_output_op(i)->get_name(),
@@ -237,19 +228,10 @@ TEST_F(NGraphExecTest, Axpy8bit) {
   auto t_y = backend->create_tensor(ng::element::i8, ng_shape_y);
   t_y->write(&v_x, sizeof(v_x));
 
-  // Allocate tensor for the result(s)
-  vector<shared_ptr<ng::runtime::Tensor>> outputs;
-  for (size_t i = 0; i < ng_function->get_output_size(); i++) {
-    auto shape = ng_function->get_output_shape(i);
-    auto elem_type = ng_function->get_output_element_type(i);
-    auto t_result = backend->create_tensor(elem_type, shape);
-    outputs.push_back(t_result);
-  }
-
   // Execute the nGraph function.
-  cout << "Calling nGraph function\n";
   auto exec = backend->compile(ng_function);
-  exec->call(outputs, {t_x, t_y});
+  vector<shared_ptr<ng::runtime::Tensor>> outputs;
+  exec->call({t_x, t_y}, outputs);
 
   for (size_t i = 0; i < ng_function->get_output_size(); i++) {
     DumpNGTensor<int8>(cout, ng_function->get_output_op(i)->get_name(),

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -183,9 +183,9 @@ void Compare(Tensor& T1, Tensor& T2, float tol) {
   // Assert type
   ASSERT_EQ(T1.dtype(), T2.dtype()) << "Types of T1 and T2 did not match";
 
-  auto T_size = T1.flat<float>().size();
-  auto T1_data = T1.flat<float>().data();
-  auto T2_data = T2.flat<float>().data();
+  auto T_size = T1.unaligned_flat<float>().size();
+  auto T1_data = T1.unaligned_flat<float>().data();
+  auto T2_data = T2.unaligned_flat<float>().data();
   for (int k = 0; k < T_size; k++) {
     auto a = T1_data[k];
     auto b = T2_data[k];
@@ -304,9 +304,9 @@ void Compare(const Tensor& T1, const Tensor& T2, float rtol, float atol) {
                             "expected output datatype."
                          << dtype;
   }
-  auto T_size = T1.unaligned_flat<T>().size();
-  auto T1_data = T1.unaligned_flat<T>().data();
-  auto T2_data = T2.unaligned_flat<T>().data();
+  auto T_size = T1.flat<T>().size();
+  auto T1_data = T1.flat<T>().data();
+  auto T2_data = T2.flat<T>().data();
   bool is_comparable = false;
 
   for (int k = 0; k < T_size; k++) {

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -304,9 +304,9 @@ void Compare(const Tensor& T1, const Tensor& T2, float rtol, float atol) {
                             "expected output datatype."
                          << dtype;
   }
-  auto T_size = T1.flat<T>().size();
-  auto T1_data = T1.flat<T>().data();
-  auto T2_data = T2.flat<T>().data();
+  auto T_size = T1.unaligned_flat<T>().size();
+  auto T1_data = T1.unaligned_flat<T>().data();
+  auto T2_data = T2.unaligned_flat<T>().data();
   bool is_comparable = false;
 
   for (int k = 0; k < T_size; k++) {


### PR DESCRIPTION
This PR changes the current OV backend implementation to support
output tensors with dynamic shapes. This is done by letting OV allocate
and manage output tensors. After execution of each encapsulate, output tensors
managed by OV are fetched using the GetBlob() API and the ownership is transferred
over to TF without additional intermediate copies.