### PR TITLE
Copy libiomp5.so and libmklml_intel.so when building with Intel TF

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -100,7 +100,7 @@ def main():
         help=
         "Use Intel TensorFlow for either building from source or prebuilt, in \n"
         + "conjunction with --use_prebuilt_tensorflow.",
-        action="store")
+        action="store_true")
 
     parser.add_argument(
         '--use_grappler_optimizer',

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -293,7 +293,6 @@ def main():
             tf_lib_dir = tf.sysconfig.get_lib()
             tf_lib_file = os.path.join(tf_lib_dir, tf_fmwk_lib_name)
             print("SYSCFG LIB: ", tf_lib_file)
-            import pdb;pdb.set_trace()
             dst_dir = os.path.join(artifacts_location, "tensorflow")
             if not os.path.isdir(dst_dir):
                 os.mkdir(dst_dir)

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -100,6 +100,7 @@ def main():
         help=
         "Use Intel TensorFlow for either building from source or prebuilt, in \n"
         + "conjunction with --use_prebuilt_tensorflow.",
+        default='',
         action="store_true")
 
     parser.add_argument(
@@ -220,6 +221,7 @@ def main():
 
     if arguments.use_intel_tensorflow != '':
         use_intel_tf = True
+        print("Using Intel Tensorflow")
 
     # The cxx_abi flag is translated to _GLIBCXX_USE_CXX11_ABI
     # For gcc older than 5.3, this flag is set to 0 and for newer ones,
@@ -257,6 +259,7 @@ def main():
         # This function copies the .so files from
         # use_tensorflow_from_location/artifacts/tensorflow to
         # artifacts/tensorflow
+        print(use_intel_tf)
         copy_tf_to_artifacts(tf_version, tf_in_artifacts, tf_whl_loc,
                              use_intel_tf)
         os.chdir(cwd)

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -259,7 +259,6 @@ def main():
         # This function copies the .so files from
         # use_tensorflow_from_location/artifacts/tensorflow to
         # artifacts/tensorflow
-        print(use_intel_tf)
         copy_tf_to_artifacts(tf_version, tf_in_artifacts, tf_whl_loc,
                              use_intel_tf)
         os.chdir(cwd)
@@ -286,6 +285,20 @@ def main():
                           "https://github.com/tensorflow/tensorflow.git",
                           tf_version)
             os.chdir(pwd_now)
+            # Finally, copy the libtensorflow_framework.so to the artifacts
+            tf_fmwk_lib_name = 'libtensorflow_framework.so.2'
+            if (platform.system() == 'Darwin'):
+                tf_fmwk_lib_name = 'libtensorflow_framework.2.dylib'
+            import tensorflow as tf
+            tf_lib_dir = tf.sysconfig.get_lib()
+            tf_lib_file = os.path.join(tf_lib_dir, tf_fmwk_lib_name)
+            print("SYSCFG LIB: ", tf_lib_file)
+            import pdb;pdb.set_trace()
+            dst_dir = os.path.join(artifacts_location, "tensorflow")
+            if not os.path.isdir(dst_dir):
+                os.mkdir(dst_dir)
+            dst = os.path.join(dst_dir, tf_fmwk_lib_name)
+            shutil.copyfile(tf_lib_file, dst)
         else:
             print("Building TensorFlow from source")
             # Download TensorFlow
@@ -308,14 +321,14 @@ def main():
             # will be 1
             cxx_abi = install_tensorflow(venv_dir, artifacts_location)
 
-        # This function copies the .so files from
-        # use_tensorflow_from_location/artifacts/tensorflow to
-        # artifacts/tensorflow
-        cwd = os.getcwd()
-        os.chdir(tf_src_dir)
-        dst_dir = os.path.join(artifacts_location, "tensorflow")
-        copy_tf_to_artifacts(tf_version, dst_dir, None, use_intel_tf)
-        os.chdir(cwd)
+            # This function copies the .so files from
+            # use_tensorflow_from_location/artifacts/tensorflow to
+            # artifacts/tensorflow
+            cwd = os.getcwd()
+            os.chdir(tf_src_dir)
+            dst_dir = os.path.join(artifacts_location, "tensorflow")
+            copy_tf_to_artifacts(tf_version, dst_dir, None, use_intel_tf)
+            os.chdir(cwd)
 
     if not arguments.use_prebuilt_openvino:
         openvino_version = "releases/2021/1"

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -100,7 +100,7 @@ def main():
         help=
         "Use Intel TensorFlow for either building from source or prebuilt, in \n"
         + "conjunction with --use_prebuilt_tensorflow.",
-        action="store_true")
+        action="store")
 
     parser.add_argument(
         '--use_grappler_optimizer',

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -305,21 +305,14 @@ def main():
             # will be 1
             cxx_abi = install_tensorflow(venv_dir, artifacts_location)
 
-        # Finally, copy the libtensorflow_framework.so to the artifacts so that
-        # we can run c++ tests from that location later
-        tf_fmwk_lib_name = 'libtensorflow_framework.so.2'
-        if (platform.system() == 'Darwin'):
-            tf_fmwk_lib_name = 'libtensorflow_framework.2.dylib'
-        import tensorflow as tf
-        tf_lib_dir = tf.sysconfig.get_lib()
-        tf_lib_file = os.path.join(tf_lib_dir, tf_fmwk_lib_name)
-        print("SYSCFG LIB: ", tf_lib_file)
+        # This function copies the .so files from
+        # use_tensorflow_from_location/artifacts/tensorflow to
+        # artifacts/tensorflow
+        cwd = os.getcwd()
+        os.chdir(tf_src_dir)
         dst_dir = os.path.join(artifacts_location, "tensorflow")
-        if not os.path.isdir(dst_dir):
-            os.mkdir(dst_dir)
-        dst = os.path.join(dst_dir, tf_fmwk_lib_name)
-        # import pdb;pdb.set_trace()
-        shutil.copyfile(tf_lib_file, dst)
+        copy_tf_to_artifacts(tf_version, dst_dir, None, use_intel_tf)
+        os.chdir(cwd)
 
     if not arguments.use_prebuilt_openvino:
         openvino_version = "releases/2021/1"

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -257,7 +257,8 @@ def main():
         # This function copies the .so files from
         # use_tensorflow_from_location/artifacts/tensorflow to
         # artifacts/tensorflow
-        copy_tf_to_artifacts(tf_version, tf_in_artifacts, tf_whl_loc)
+        copy_tf_to_artifacts(tf_version, tf_in_artifacts, tf_whl_loc,
+                             use_intel_tf)
         os.chdir(cwd)
     else:
         if arguments.use_prebuilt_tensorflow != '':
@@ -317,6 +318,7 @@ def main():
         if not os.path.isdir(dst_dir):
             os.mkdir(dst_dir)
         dst = os.path.join(dst_dir, tf_fmwk_lib_name)
+        # import pdb;pdb.set_trace()
         shutil.copyfile(tf_lib_file, dst)
 
     if not arguments.use_prebuilt_openvino:

--- a/build_tf.py
+++ b/build_tf.py
@@ -86,7 +86,8 @@ def main():
     artifacts_dir = os.path.join(pwd, 'artifacts/tensorflow')
     os.chdir("tensorflow")
 
-    copy_tf_to_artifacts(arguments.tf_version, artifacts_dir, None)
+    copy_tf_to_artifacts(arguments.tf_version, artifacts_dir, None,
+                         use_intel_tf)
 
     print('\033[1;35mTensorFlow Build finished\033[0m')
 

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -342,7 +342,7 @@ def locate_tf_whl(tf_whl_loc):
     return tf_whl
 
 
-def copy_tf_to_artifacts(tf_version, artifacts_dir, tf_prebuilt):
+def copy_tf_to_artifacts(tf_version, artifacts_dir, tf_prebuilt, use_intel_tf):
     if (tf_version.startswith("v2.")):
         tf_fmwk_lib_name = 'libtensorflow_framework.so.2'
         tf_cc_lib_name = 'libtensorflow_cc.so.2'
@@ -367,15 +367,27 @@ def copy_tf_to_artifacts(tf_version, artifacts_dir, tf_prebuilt):
     if tf_prebuilt is None:
         tf_cc_lib_file = "bazel-bin/tensorflow/" + tf_cc_lib_name
         tf_cc_fmwk_file = "bazel-bin/tensorflow/" + tf_fmwk_lib_name
+        if use_intel_tf:
+            opm_lib_file = "bazel-tensorflow/external/mkl_linux/lib/libiomp5.so"
+            mkl_lib_file = "bazel-tensorflow/external/mkl_linux/lib/libmklml_intel.so"
     else:
         tf_cc_lib_file = os.path.abspath(tf_prebuilt + '/' + tf_cc_lib_name)
         tf_cc_fmwk_file = os.path.abspath(tf_prebuilt + '/' + tf_fmwk_lib_name)
+        if use_intel_tf:
+            opm_lib_file = os.path.abspath(tf_prebuilt + '/libiomp5.so')
+            mkl_lib_file = os.path.abspath(tf_prebuilt + '/libmklml_intel.so')
     print("PWD: ", os.getcwd())
     print("Copying %s to %s" % (tf_cc_lib_file, artifacts_dir))
     shutil.copy(tf_cc_lib_file, artifacts_dir)
 
     print("Copying %s to %s" % (tf_cc_fmwk_file, artifacts_dir))
     shutil.copy(tf_cc_fmwk_file, artifacts_dir)
+    if use_intel_tf:
+        print("Copying %s to %s" % (opm_lib_file, artifacts_dir))
+        shutil.copy(opm_lib_file, artifacts_dir)
+
+        print("Copying %s to %s" % (mkl_lib_file, artifacts_dir))
+        shutil.copy(mkl_lib_file, artifacts_dir)
 
     if tf_prebuilt is not None:
         tf_whl = locate_tf_whl(tf_prebuilt)


### PR DESCRIPTION
Copy files (libiomp5.so and libmklml_intel.so) necessary to build against Intel TF to the build artifacts directory.