### PR TITLE
Cavusmustafa/tf tensor without blob

### DIFF
--- a/ngraph_bridge/executable.cc
+++ b/ngraph_bridge/executable.cc
@@ -142,7 +142,7 @@ bool Executable::call(const vector<shared_ptr<runtime::Tensor>>& inputs,
   auto func = m_network.getFunction();
   auto parameters = func->get_parameters();
   for (int i = 0; i < inputs.size(); i++) {
-    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(inputs[i]); 
+    shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(inputs[i]);
     InferenceEngine::SizeVector input_shape = tv->get_dims();
     InferenceEngine::Precision input_precision = tv->get_precision();
     InferenceEngine::Layout input_layout = tv->get_layout();
@@ -158,12 +158,11 @@ bool Executable::call(const vector<shared_ptr<runtime::Tensor>>& inputs,
 
   std::vector<InferenceEngine::MemoryBlob::Ptr> param_blobs(
       m_hoisted_params.size());
-  int i=0;
+  int i = 0;
   for (const auto& it : m_hoisted_params) {
     shared_ptr<IETensor> tv = static_pointer_cast<IETensor>(it.second);
     InferenceEngine::SizeVector param_shape = tv->get_dims();
-    InferenceEngine::Precision param_precision =
-        tv->get_precision();
+    InferenceEngine::Precision param_precision = tv->get_precision();
     InferenceEngine::Layout param_layout = tv->get_layout();
     const void* param_data_pointer = tv->get_data_ptr();
     size_t size = tv->get_byte_size();
@@ -229,8 +228,9 @@ bool Executable::call(const vector<shared_ptr<runtime::Tensor>>& inputs,
       InferenceEngine::Precision precision = desc.getPrecision();
       InferenceEngine::Layout layout = desc.getLayout();
       size_t out_size = blob->byteSize();
-      outputs[i] = std::make_shared<IETensor>(
-          (void*)data_ptr, precision, layout, shape, out_size, get_output_name(results[i]));
+      outputs[i] =
+          std::make_shared<IETensor>((void*)data_ptr, precision, layout, shape,
+                                     out_size, get_output_name(results[i]));
     }
   }
 

--- a/ngraph_bridge/ie_tensor.h
+++ b/ngraph_bridge/ie_tensor.h
@@ -33,20 +33,38 @@ class IETensor : public ngraph::runtime::Tensor {
            const ngraph::PartialShape& shape);
   IETensor(const ngraph::element::Type& element_type,
            const ngraph::Shape& shape, void* memory_pointer);
-  IETensor(InferenceEngine::Blob::Ptr blob);
+  // IETensor(std::shared_ptr<IE_Data> ie_data);
+  IETensor(const void* data_pointer, InferenceEngine::Precision precision,
+           InferenceEngine::Layout layout, InferenceEngine::SizeVector shape,
+           size_t byte_size, std::string name);
+  IETensor(std::string name);
   ~IETensor() override;
 
   void write(const void* src, size_t bytes) override;
   void read(void* dst, size_t bytes) const override;
 
   const void* get_data_ptr() const;
-  InferenceEngine::Blob::Ptr get_blob() { return m_blob; }
+  // std::shared_ptr<IE_Data> get_ie_data() const { return m_ie_data; };
+
+  InferenceEngine::Precision get_precision() const;
+  InferenceEngine::Layout get_layout() const;
+  InferenceEngine::SizeVector get_dims() const;
+  void set_name(std::string name);
+  std::string get_name() const;
+  size_t get_byte_size() const;
 
  private:
   IETensor(const IETensor&) = delete;
   IETensor(IETensor&&) = delete;
   IETensor& operator=(const IETensor&) = delete;
-  InferenceEngine::Blob::Ptr m_blob;
+  // std::shared_ptr<IE_Data> m_ie_data;
+
+  const void* m_data_pointer;
+  InferenceEngine::Precision m_precision;
+  InferenceEngine::Layout m_layout;
+  InferenceEngine::SizeVector m_shape;
+  size_t m_byte_size;
+  std::string m_name;
 };
 
 // A simple TensorBuffer implementation that allows us to create Tensors that

--- a/ngraph_bridge/ie_utils.h
+++ b/ngraph_bridge/ie_utils.h
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2017-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+// The backend manager class is a singelton class that interfaces with the
+// bridge to provide necessary backend
+
+#ifndef IE_UTILS_H_
+#define IE_UTILS_H_
+
+#include <atomic>
+#include <ie_core.hpp>
+#include <mutex>
+#include <ostream>
+#include <vector>
+
+class IE_Utils {
+ public:
+
+  static void CreateBlob(InferenceEngine::TensorDesc& desc,
+                         InferenceEngine::Precision& precision,
+                         const void* data_ptr, size_t byte_size,
+                         InferenceEngine::MemoryBlob::Ptr& blob_ptr) {
+#define MAKE_IE_BLOB(type_, desc_, ptr_, size_)                         \
+  do {                                                                  \
+    if (ptr_ == nullptr) {                                              \
+      blob_ptr = std::make_shared<InferenceEngine::TBlob<type_>>(desc); \
+      blob_ptr->allocate();                                             \
+    } else {                                                            \
+      blob_ptr = std::make_shared<InferenceEngine::TBlob<type_>>(       \
+          desc, (type_*)ptr_, size_);                                   \
+    }                                                                   \
+  } while (0)
+    switch (precision) {
+      case InferenceEngine::Precision::FP32:
+        MAKE_IE_BLOB(float, desc, (float*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::U8:
+        MAKE_IE_BLOB(uint8_t, desc, (uint8_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::I8:
+        MAKE_IE_BLOB(int8_t, desc, (int8_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::U16:
+        MAKE_IE_BLOB(uint16_t, desc, (uint16_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::I16:
+        MAKE_IE_BLOB(int16_t, desc, (int16_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::I32:
+        MAKE_IE_BLOB(int32_t, desc, (int32_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::U64:
+        MAKE_IE_BLOB(uint64_t, desc, (uint64_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::I64:
+        MAKE_IE_BLOB(int64_t, desc, (int64_t*)data_ptr, byte_size);
+        break;
+      case InferenceEngine::Precision::BOOL:
+        MAKE_IE_BLOB(uint8_t, desc, (uint8_t*)data_ptr, byte_size);
+        break;
+      default:
+        THROW_IE_EXCEPTION << "Can't create IE blob for type "
+                           << precision.name();
+    }
+  }
+};
+
+#endif
+// IE_UTILS_H

--- a/ngraph_bridge/ie_utils.h
+++ b/ngraph_bridge/ie_utils.h
@@ -28,7 +28,6 @@
 
 class IE_Utils {
  public:
-
   static void CreateBlob(InferenceEngine::TensorDesc& desc,
                          InferenceEngine::Precision& precision,
                          const void* data_ptr, size_t byte_size,


### PR DESCRIPTION
This is the first PR for the modular backend.
IE Blob is removed from IE_Tensor. Blobs are created during execution (in call() function of Executable). This modification is required to enable batch parallelism for HDDL later.
A new file, "ie_utils.hpp" is created for generic ie related operations. It only includes a function to create ie blobs for now. It will include additional functions in next PRs.