### PR TITLE
Simplify layout conversion and padding helpers

### DIFF
--- a/ngraph_bridge/ngraph_builder.h
+++ b/ngraph_bridge/ngraph_builder.h
@@ -24,10 +24,7 @@
 
 #include "ngraph/ngraph.hpp"
 
-#include "logging/ngraph_log.h"
-
 namespace tensorflow {
-
 namespace ngraph_bridge {
 
 class Builder {
@@ -39,6 +36,12 @@ class Builder {
 
   using OpMap = std::unordered_map<std::string,
                                    std::vector<ngraph::Output<ngraph::Node>>>;
+  using ConstMap = std::map<
+      DataType,
+      std::pair<std::function<Status(const Node*, ngraph::element::Type,
+                                     ngraph::Output<ngraph::Node>&)>,
+                const ngraph::element::Type>>;
+  static const Builder::ConstMap& TF_NGRAPH_CONST_MAP();
 
   template <typename T>
   static void MakePadding(const std::string& tf_padding_type,
@@ -47,102 +50,18 @@ class Builder {
                           const ngraph::Strides& ng_strides,
                           const ngraph::Shape& ng_dilations,
                           T& ng_padding_below, T& ng_padding_above) {
-    ngraph::Shape ng_dilation_kernel_shape{
-        (ng_kernel_shape[0] - 1) * ng_dilations[0] + 1,
-        (ng_kernel_shape[1] - 1) * ng_dilations[1] + 1};
-
-    MakePadding(tf_padding_type, ng_image_shape, ng_dilation_kernel_shape,
-                ng_strides, ng_padding_below, ng_padding_above);
-  }
-
-  template <typename T>
-  static void MakePadding3D(const std::string& tf_padding_type,
-                            const ngraph::Shape& ng_image_shape,
-                            const ngraph::Shape& ng_kernel_shape,
-                            const ngraph::Strides& ng_strides,
-                            const ngraph::Shape& ng_dilations,
-                            T& ng_padding_below, T& ng_padding_above) {
-    ngraph::Shape ng_dilation_kernel_shape{
-        (ng_kernel_shape[0] - 1) * ng_dilations[0] + 1,
-        (ng_kernel_shape[1] - 1) * ng_dilations[1] + 1,
-        (ng_kernel_shape[2] - 1) * ng_dilations[2] + 1};
-
-    MakePadding3D(tf_padding_type, ng_image_shape, ng_dilation_kernel_shape,
-                  ng_strides, ng_padding_below, ng_padding_above);
-  }
-
-  template <typename T>
-  static void MakePadding(const std::string& tf_padding_type,
-                          const ngraph::Shape& ng_image_shape,
-                          const ngraph::Shape& ng_kernel_shape,
-                          const ngraph::Strides& ng_strides,
-                          T& ng_padding_below, T& ng_padding_above) {
     if (tf_padding_type == "SAME") {
-      for (size_t i = 0; i < 2; i++) {
-        size_t image_size = ng_image_shape[i];
-        size_t filter_shape = ng_kernel_shape[i];
-        size_t filter_stride = ng_strides[i];
-
-        int64 padding_needed;
-        if (image_size % filter_stride == 0) {
-          padding_needed = filter_shape - filter_stride;
-        } else {
-          padding_needed = filter_shape - (image_size % filter_stride);
-        }
-        if (padding_needed < 0) {
-          padding_needed = 0;
-        }
-
-        size_t padding_lhs = padding_needed / 2;
-        size_t padding_rhs = padding_needed - padding_lhs;
-        ng_padding_below[i] = padding_lhs;
-        ng_padding_above[i] = padding_rhs;
-      }
+      ngraph::Shape img_shape = {0, 0};
+      img_shape.insert(img_shape.end(), ng_image_shape.begin(),
+                       ng_image_shape.end());
+      ngraph::infer_auto_padding(img_shape, ng_kernel_shape, ng_strides,
+                                 ng_dilations, ngraph::op::PadType::SAME_UPPER,
+                                 ng_padding_above, ng_padding_below);
+    } else if (tf_padding_type == "VALID") {
+      ng_padding_below.assign(ng_image_shape.size(), 0);
+      ng_padding_above.assign(ng_image_shape.size(), 0);
     }
-
-    NGRAPH_VLOG(3) << "ng_padding_below: " << ngraph::join(ng_padding_below);
-    NGRAPH_VLOG(3) << "ng_padding_above: " << ngraph::join(ng_padding_above);
   }
-
-  template <typename T>
-  static void MakePadding3D(const std::string& tf_padding_type,
-                            const ngraph::Shape& ng_image_shape,
-                            const ngraph::Shape& ng_kernel_shape,
-                            const ngraph::Strides& ng_strides,
-                            T& ng_padding_below, T& ng_padding_above) {
-    if (tf_padding_type == "SAME") {
-      for (size_t i = 0; i < 3; i++) {
-        size_t image_size = ng_image_shape[i];
-        size_t filter_shape = ng_kernel_shape[i];
-        size_t filter_stride = ng_strides[i];
-
-        int64 padding_needed;
-        if (image_size % filter_stride == 0) {
-          padding_needed = filter_shape - filter_stride;
-        } else {
-          padding_needed = filter_shape - (image_size % filter_stride);
-        }
-        if (padding_needed < 0) {
-          padding_needed = 0;
-        }
-
-        size_t padding_lhs = padding_needed / 2;
-        size_t padding_rhs = padding_needed - padding_lhs;
-        ng_padding_below[i] = padding_lhs;
-        ng_padding_above[i] = padding_rhs;
-      }
-    }
-
-    NGRAPH_VLOG(3) << "ng_padding_below: " << ngraph::join(ng_padding_below);
-    NGRAPH_VLOG(3) << "ng_padding_above: " << ngraph::join(ng_padding_above);
-  }
-
-  using ConstMap = std::map<
-      DataType,
-      std::pair<std::function<Status(const Node*, ngraph::element::Type,
-                                     ngraph::Output<ngraph::Node>&)>,
-                const ngraph::element::Type>>;
-  static const Builder::ConstMap& TF_NGRAPH_CONST_MAP();
 
   // This function is used to trace which ng node came from which tf node
   // It does 3 things:
@@ -154,17 +73,9 @@ class Builder {
   // 3. Prints a log if NGRAPH_TF_LOG_PLACEMENT=1
   static void SetTracingInfo(const std::string& op_name,
                              const ngraph::Output<ngraph::Node> ng_node);
-
- private:
-  static void ComputeScaleOffsetFolded(const uint& num_bits,
-                                       const bool& unsigned_type,
-                                       const bool& scaled, const int min_range,
-                                       const int max_range, float* scale,
-                                       int* offset);
 };
 
 }  // namespace ngraph_bridge
-
 }  // namespace tensorflow
 
 #endif

--- a/ngraph_bridge/ngraph_conversions.h
+++ b/ngraph_bridge/ngraph_conversions.h
@@ -74,104 +74,43 @@ void Transpose3D(std::shared_ptr<ngraph::Node>& node) {
 
 namespace detail {
 template <typename T>
-void NhwcToNGraph(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[1];
-  dst[1] = src[2];
-}
-
-void NhwcToNGraph(ngraph::Output<ngraph::Node>& ng_node);
-
-template <typename T>
-void NdhwcToNGraph(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[1];
-  dst[1] = src[2];
-  dst[2] = src[3];
-}
-
-void NdhwcToNGraph(ngraph::Output<ngraph::Node>& ng_node);
-
-template <typename T>
-void NchwToNGraph(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[2];
-  dst[1] = src[3];
+void NHWCtoHW(const std::vector<T>& src, std::vector<size_t>& dst) {
+  if (dst.size() >= 2) {
+    dst[0] = src[1];
+    dst[1] = src[2];
+  }
+  if (dst.size() >= 3) {
+    dst[2] = src[3];
+  }
 }
 
 template <typename T>
-void NcdhwToNGraph(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[2];
-  dst[1] = src[3];
-  dst[2] = src[4];
+void NCHWtoHW(const std::vector<T>& src, std::vector<size_t>& dst) {
+  if (dst.size() >= 2) {
+    dst[0] = src[2];
+    dst[1] = src[3];
+  }
+  if (dst.size() >= 3) {
+    dst[2] = src[4];
+  }
 }
+}
+
+void NHWCtoNCHW(const string& op_name, bool is_nhwc,
+                ngraph::Output<ngraph::Node>& ng_input);
+
+void NCHWtoNHWC(const string& op_name, bool is_nhwc,
+                ngraph::Output<ngraph::Node>& ng_node);
 
 template <typename T>
-void NhwcToNchw(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[0];
-  dst[1] = src[3];
-  dst[2] = src[1];
-  dst[3] = src[2];
-}
-
-template <typename T>
-void NdhwcToNcdhw(const std::vector<T>& src, std::vector<size_t>& dst) {
-  dst[0] = src[0];
-  dst[1] = src[4];
-  dst[2] = src[1];
-  dst[3] = src[2];
-  dst[4] = src[3];
-}
-}
-
-void BatchToNGraph(const string& op_name, bool is_nhwc,
-                   ngraph::Output<ngraph::Node>& ng_input);
-
-void BatchToNGraph3D(const string& op_name, bool is_ndhwc,
-                     ngraph::Output<ngraph::Node>& ng_input);
-
-template <typename T>
-void BatchedOpParamToNGraph(bool is_nhwc, const std::vector<T>& src,
-                            std::vector<size_t>& dst) {
+void NHWCtoHW(bool is_nhwc, const std::vector<T>& src,
+              std::vector<size_t>& dst) {
   if (is_nhwc) {
-    detail::NhwcToNGraph(src, dst);
+    detail::NHWCtoHW(src, dst);
   } else {
-    detail::NchwToNGraph(src, dst);
+    detail::NCHWtoHW(src, dst);
   }
 }
-
-template <typename T>
-void BatchedOpParam3DToNGraph(bool is_ndhwc, const std::vector<T>& src,
-                              std::vector<size_t>& dst) {
-  if (is_ndhwc) {
-    detail::NdhwcToNGraph(src, dst);
-  } else {
-    detail::NcdhwToNGraph(src, dst);
-  }
-}
-
-template <typename T>
-void BatchedOpParamReshape(bool is_nhwc, const std::vector<T>& src,
-                           std::vector<size_t>& dst) {
-  if (is_nhwc) {
-    detail::NhwcToNchw(src, dst);
-  } else {
-    dst = src;
-  }
-}
-
-template <typename T>
-void BatchedOpParamReshape3D(bool is_ndhwc, const std::vector<T>& src,
-                             std::vector<size_t>& dst) {
-  if (is_ndhwc) {
-    detail::NdhwcToNcdhw(src, dst);
-  } else {
-    dst = src;
-  }
-}
-
-void BatchToTensorflow(const string& op_name, bool is_nhwc,
-                       ngraph::Output<ngraph::Node>& ng_node);
-
-void BatchToTensorflow3D(const string& op_name, bool is_ndhwc,
-                         ngraph::Output<ngraph::Node>& ng_node);
 
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/test/conversions.cpp
+++ b/test/conversions.cpp
@@ -18,63 +18,62 @@
 #include "ngraph_bridge/ngraph_conversions.h"
 
 using namespace std;
-namespace ng = ngraph;
 
 namespace tensorflow {
 namespace ngraph_bridge {
 namespace testing {
 
 TEST(conversions, transpose) {
-  ng::Output<ng::Node> node =
-      make_shared<ng::op::Parameter>(ng::element::f32, ng::Shape{2, 3, 4, 5});
+  ngraph::Output<ngraph::Node> node = make_shared<ngraph::op::Parameter>(
+      ngraph::element::f32, ngraph::Shape{2, 3, 4, 5});
   Transpose<3, 2, 0, 1>(node);
-  ASSERT_EQ(node.get_shape(), (ng::Shape{5, 4, 2, 3}));
+  ASSERT_EQ(node.get_shape(), (ngraph::Shape{5, 4, 2, 3}));
 }
 
 TEST(conversions, batch_to_tensorflow_nchw) {
-  auto shape = ng::Shape{2, 3, 4, 5};
-  ngraph::Output<ng::Node> node =
-      make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToTensorflow("tag", false, node);
+  auto shape = ngraph::Shape{2, 3, 4, 5};
+  ngraph::Output<ngraph::Node> node =
+      make_shared<ngraph::op::Parameter>(ngraph::element::f32, shape);
+  NCHWtoNHWC("tag", false, node);
   ASSERT_EQ(node.get_shape(), shape);
 }
 
 TEST(conversions, batch_to_tensorflow_nhwc) {
-  auto shape = ng::Shape{2, 3, 4, 5};
-  ngraph::Output<ng::Node> node =
-      make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToTensorflow("tag", true, node);
-  ASSERT_EQ(node.get_shape(), (ng::Shape{2, 4, 5, 3}));
+  auto shape = ngraph::Shape{2, 3, 4, 5};
+  ngraph::Output<ngraph::Node> node =
+      make_shared<ngraph::op::Parameter>(ngraph::element::f32, shape);
+  NCHWtoNHWC("tag", true, node);
+  ASSERT_EQ(node.get_shape(), (ngraph::Shape{2, 4, 5, 3}));
 }
 
 TEST(conversions, batch_to_ngraph_nchw) {
-  auto shape = ng::Shape{2, 3, 4, 5};
-  ngraph::Output<ng::Node> node =
-      make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToNGraph("tag", false, node);
+  auto shape = ngraph::Shape{2, 3, 4, 5};
+  ngraph::Output<ngraph::Node> node =
+      make_shared<ngraph::op::Parameter>(ngraph::element::f32, shape);
+  NHWCtoNCHW("tag", false, node);
   ASSERT_EQ(node.get_shape(), shape);
 }
 
 TEST(conversions, param_to_ngraph_nchw) {
   vector<size_t> in1{1, 2, 3, 4};
   vector<size_t> out1(4);
-  BatchedOpParamToNGraph(false, in1, out1);
+  NHWCtoHW(false, in1, out1);
   ASSERT_EQ(out1[0], in1[2]);
   ASSERT_EQ(out1[1], in1[3]);
 }
 
 TEST(conversions, batch_to_ngraph_nhwc) {
-  auto shape = ng::Shape{2, 3, 4, 5};
-  ngraph::Output<ng::Node> node =
-      make_shared<ng::op::Parameter>(ng::element::f32, shape);
-  BatchToNGraph("tag", true, node);
-  ASSERT_EQ(node.get_shape(), (ng::Shape{2, 5, 3, 4}));
+  auto shape = ngraph::Shape{2, 3, 4, 5};
+  ngraph::Output<ngraph::Node> node =
+      make_shared<ngraph::op::Parameter>(ngraph::element::f32, shape);
+  NHWCtoNCHW("tag", true, node);
+  ASSERT_EQ(node.get_shape(), (ngraph::Shape{2, 5, 3, 4}));
 }
 
 TEST(conversions, param_to_ngraph_nhwc) {
   vector<size_t> in1{1, 2, 3, 4};
   vector<size_t> out1(4);
-  BatchedOpParamToNGraph(true, in1, out1);
+  NHWCtoHW(true, in1, out1);
   ASSERT_EQ(out1[0], in1[1]);
   ASSERT_EQ(out1[1], in1[2]);
 }

--- a/test/padding.cpp
+++ b/test/padding.cpp
@@ -16,23 +16,21 @@
 #include "gtest/gtest.h"
 
 #include "ngraph_bridge/ngraph_builder.h"
-#include "ngraph_bridge/ngraph_utils.h"
 
 using namespace std;
-namespace ng = ngraph;
 
 namespace tensorflow {
-
 namespace ngraph_bridge {
-
 namespace testing {
 
 // valid padding is a noop
 TEST(padding, valid) {
-  ng::Shape ng_padding_below{0, 0};
-  ng::Shape ng_padding_above{0, 0};
-  Builder::MakePadding(std::string("VALID"), ng::Shape{4, 5}, ng::Shape{2, 3},
-                       ng::Strides{1, 1}, ng_padding_below, ng_padding_above);
+  ngraph::CoordinateDiff ng_padding_below;
+  ngraph::CoordinateDiff ng_padding_above;
+  Builder::MakePadding(string("VALID"), ngraph::Shape{4, 5},
+                       ngraph::Shape{2, 3}, ngraph::Strides{1, 1},
+                       ngraph::Strides{0, 0}, ng_padding_below,
+                       ng_padding_above);
   ASSERT_EQ(ng_padding_below[0], 0);
   ASSERT_EQ(ng_padding_below[1], 0);
   ASSERT_EQ(ng_padding_above[0], 0);
@@ -40,10 +38,11 @@ TEST(padding, valid) {
 }
 
 TEST(padding, divisible) {
-  ng::Shape ng_padding_below{0, 0};
-  ng::Shape ng_padding_above{0, 0};
-  Builder::MakePadding(std::string("SAME"), ng::Shape{8, 9}, ng::Shape{2, 3},
-                       ng::Strides{1, 1}, ng_padding_below, ng_padding_above);
+  ngraph::CoordinateDiff ng_padding_below;
+  ngraph::CoordinateDiff ng_padding_above;
+  Builder::MakePadding(string("SAME"), ngraph::Shape{8, 9}, ngraph::Shape{2, 3},
+                       ngraph::Strides{1, 1}, ngraph::Strides{1, 1},
+                       ng_padding_below, ng_padding_above);
   ASSERT_EQ(ng_padding_below[0], 0);
   ASSERT_EQ(ng_padding_below[1], 1);
   ASSERT_EQ(ng_padding_above[0], 1);
@@ -51,10 +50,12 @@ TEST(padding, divisible) {
 }
 
 TEST(padding, indivisible) {
-  ng::Shape ng_padding_below{0, 0};
-  ng::Shape ng_padding_above{0, 0};
-  Builder::MakePadding(std::string("SAME"), ng::Shape{10, 10}, ng::Shape{4, 4},
-                       ng::Strides{3, 3}, ng_padding_below, ng_padding_above);
+  ngraph::CoordinateDiff ng_padding_below;
+  ngraph::CoordinateDiff ng_padding_above;
+  Builder::MakePadding(string("SAME"), ngraph::Shape{10, 10},
+                       ngraph::Shape{4, 4}, ngraph::Strides{3, 3},
+                       ngraph::Strides{1, 1}, ng_padding_below,
+                       ng_padding_above);
   ASSERT_EQ(ng_padding_below[0], 1);
   ASSERT_EQ(ng_padding_below[1], 1);
   ASSERT_EQ(ng_padding_above[0], 2);
@@ -62,7 +63,5 @@ TEST(padding, indivisible) {
 }
 
 }  // namespace testing
-
 }  // namespace ngraph_bridge
-
 }  // namespace tensorflow


### PR DESCRIPTION
* Remove unnecessary conversion helpers
* Rename conversion helpers to be explict about layouts, e.g. `NCHWtoNHWC`
* Remove duplicate padding computations and use nGraph API for padding
* Remove duplicated Maxpool3D translation and use same Maxpool translation for 2D/3D