### PR TITLE
Inaccurate output with transpose sinking for graphs with multi-outputs nodes

### DIFF
--- a/test/opexecuter.h
+++ b/test/opexecuter.h
@@ -83,8 +83,6 @@ class OpExecuter {
   Scope tf_scope_;
   const string test_op_type_;
   const std::vector<Output> sess_run_fetchoutputs_;
-
-  void ValidateGraph(const Graph& graph, const vector<string> allowed_nodes);
 };
 
 }  // namespace testing

--- a/test/tests_linux_cpu.txt
+++ b/test/tests_linux_cpu.txt
@@ -62,5 +62,8 @@ ArrayOps.SplitVZeroSizeNegSplit
 
 MathOps.FloorModNegFloat #Floor_mod supports only I32 precision of inputs
 
+# The following test is a reproducer for the Alexnet accuracy issue related to TS
+TransposeSinking.MultiOutputConV
+
 
 


### PR DESCRIPTION
Add a reproducer test for debugging Alexnet accuracy issue related to TransposeSinking. Without TS the model gives accurate results.
Also, remove the ValidateGraph API from OpExecutor.