### PR TITLE
Enable FC-DenseNet 103

### DIFF
--- a/ngraph_bridge/ngraph_assign_clusters.cc
+++ b/ngraph_bridge/ngraph_assign_clusters.cc
@@ -557,16 +557,17 @@ Status AssignClusters(Graph* graph) {
   // Remove Const with outputs to another cluster from being clustered
   NGRAPH_VLOG(2) << "Check for Const->Result ";
   for (auto node : graph->op_nodes()) {
-    // TODO: Other nodes (such as those with static inputs) may also require deassignment here
+    // TODO: Other nodes (such as those with static inputs) may also require
+    // deassignment here
     if (node->type_string() == "Const") {
       auto src_index = cluster_map.at(node)->index;
-      NGRAPH_VLOG(2) << "Cluster index of constant node " << node->name() << ": "
-           << src_index << endl;
+      NGRAPH_VLOG(2) << "Cluster index of constant node " << node->name()
+                     << ": " << src_index << endl;
       for (auto edge : node->out_edges()) {
         auto dst = edge->dst();
         auto dst_index = cluster_map.at(dst)->index;
         NGRAPH_VLOG(2) << "Cluster index of out edge " << dst->name() << ": "
-             << dst_index << endl;
+                       << dst_index << endl;
         if (src_index != -1 && src_index != dst_index) {
           NGRAPH_VLOG(2) << "Deassigning node: " << node->name() << endl;
           // Remove it from its current cluster

--- a/ngraph_bridge/ngraph_assign_clusters.cc
+++ b/ngraph_bridge/ngraph_assign_clusters.cc
@@ -554,6 +554,36 @@ Status AssignClusters(Graph* graph) {
 
   NGRAPH_VLOG(2) << "Contraction done";
 
+  // Remove Const with outputs to another cluster from being clustered
+  NGRAPH_VLOG(2) << "Check for Const->Result ";
+  for (auto node : graph->op_nodes()) {
+    // TODO: Other nodes (such as those with static inputs) may also require deassignment here
+    if (node->type_string() == "Const") {
+      auto src_index = cluster_map.at(node)->index;
+      NGRAPH_VLOG(2) << "Cluster index of constant node " << node->name() << ": "
+           << src_index << endl;
+      for (auto edge : node->out_edges()) {
+        auto dst = edge->dst();
+        auto dst_index = cluster_map.at(dst)->index;
+        NGRAPH_VLOG(2) << "Cluster index of out edge " << dst->name() << ": "
+             << dst_index << endl;
+        if (src_index != -1 && src_index != dst_index) {
+          NGRAPH_VLOG(2) << "Deassigning node: " << node->name() << endl;
+          // Remove it from its current cluster
+          auto& cluster_info = cluster_map.at(node);
+          cluster_info->nodes.erase(node);
+
+          // Assign it to TF cluster (index =-1), which is not really a cluster
+          // just a collection of nodes
+          node->ClearAttr("_ngraph_marked_for_clustering");
+          cluster_map[node] = std::make_shared<Cluster>();
+          cluster_map.at(node)->index = -1;
+          break;
+        }
+      }
+    }
+  }
+
   NGRAPH_VLOG(2) << "Starting tagging";
   std::set<Cluster*> seen;
   unordered_map<int, int> cluster_to_encapsulate;

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2009,8 +2009,18 @@ static Status TranslateRelu6Op(const Node* op,
 static Status TranslateReshapeOp(
     const Node* op, const std::vector<const Tensor*>& static_input_map,
     Builder::OpMap& ng_op_map) {
-  ng::Output<ng::Node> ng_input, ng_shape;
-  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, ng_input, ng_shape));
+  ng::Output<ng::Node> ng_input, ng_shape_op;
+  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, ng_input, ng_shape_op));
+
+  NGRAPH_VLOG(3) << "Input shape: " << ng::join(ng_input.get_shape());
+
+  std::vector<int64> shape;
+  TF_RETURN_IF_ERROR(GetStaticInputVector(op, 1, static_input_map, &shape));
+
+  NGRAPH_VLOG(3) << "Requested result shape: " << ng::join(shape);
+
+  auto ng_shape = ConstructNgNode<opset::Constant>(
+      op->name(), ng::element::i64, ng::Shape{shape.size()}, shape);
   SaveNgOp(ng_op_map, op->name(), ConstructNgNode<opset::Reshape>(
                                       op->name(), ng_input, ng_shape, false));
   return Status::OK();

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2009,18 +2009,8 @@ static Status TranslateRelu6Op(const Node* op,
 static Status TranslateReshapeOp(
     const Node* op, const std::vector<const Tensor*>& static_input_map,
     Builder::OpMap& ng_op_map) {
-  ng::Output<ng::Node> ng_input, ng_shape_op;
-  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, ng_input, ng_shape_op));
-
-  NGRAPH_VLOG(3) << "Input shape: " << ng::join(ng_input.get_shape());
-
-  std::vector<int64> shape;
-  TF_RETURN_IF_ERROR(GetStaticInputVector(op, 1, static_input_map, &shape));
-
-  NGRAPH_VLOG(3) << "Requested result shape: " << ng::join(shape);
-
-  auto ng_shape = ConstructNgNode<opset::Constant>(
-      op->name(), ng::element::i64, ng::Shape{shape.size()}, shape);
+  ng::Output<ng::Node> ng_input, ng_shape;
+  TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, ng_input, ng_shape));
   SaveNgOp(ng_op_map, op->name(), ConstructNgNode<opset::Reshape>(
                                       op->name(), ng_input, ng_shape, false));
   return Status::OK();

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -213,8 +213,6 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
     set_attributes_map["Pad"] = SetStaticInputs({1});
     set_attributes_map["PadV2"] = SetStaticInputs({1, 2});
     set_attributes_map["Prod"] = SetStaticInputs({1});
-    set_attributes_map["Reshape"] = SetStaticInputs({1});
-    set_attributes_map["Shape"] = SetStaticInputs({0});
     set_attributes_map["Slice"] = SetStaticInputs({1, 2});
     set_attributes_map["Split"] = SetStaticInputs({0});
     set_attributes_map["SplitV"] = SetStaticInputs({1, 2});

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -214,7 +214,6 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
     set_attributes_map["PadV2"] = SetStaticInputs({1, 2});
     set_attributes_map["Prod"] = SetStaticInputs({1});
     set_attributes_map["Reshape"] = SetStaticInputs({1});
-    set_attributes_map["Shape"] = SetStaticInputs({0});
     set_attributes_map["Slice"] = SetStaticInputs({1, 2});
     set_attributes_map["Split"] = SetStaticInputs({0});
     set_attributes_map["SplitV"] = SetStaticInputs({1, 2});

--- a/ngraph_bridge/ngraph_mark_for_clustering.cc
+++ b/ngraph_bridge/ngraph_mark_for_clustering.cc
@@ -213,6 +213,8 @@ const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
     set_attributes_map["Pad"] = SetStaticInputs({1});
     set_attributes_map["PadV2"] = SetStaticInputs({1, 2});
     set_attributes_map["Prod"] = SetStaticInputs({1});
+    set_attributes_map["Reshape"] = SetStaticInputs({1});
+    set_attributes_map["Shape"] = SetStaticInputs({0});
     set_attributes_map["Slice"] = SetStaticInputs({1, 2});
     set_attributes_map["Split"] = SetStaticInputs({0});
     set_attributes_map["SplitV"] = SetStaticInputs({1, 2});

--- a/test/graph_rewrites/assign_clusters.cc
+++ b/test/graph_rewrites/assign_clusters.cc
@@ -24,12 +24,9 @@
 #include "test/test_utilities.h"
 
 using namespace std;
-namespace ng = ngraph;
 
 namespace tensorflow {
-
 namespace ngraph_bridge {
-
 namespace testing {
 
 // Test that a "Const" fed to a static input is still coalesced with the
@@ -110,9 +107,9 @@ TEST(AssignClusters, Cone) {
   Tensor t(DT_FLOAT, TensorShape{2, 3});
 
   Node* node1;
-  ASSERT_OK(NodeBuilder("node1", "Const")
-                .Attr("dtype", DT_FLOAT)
-                .Attr("value", t)
+  ASSERT_OK(NodeBuilder("node1", "_Arg")
+                .Attr("T", DT_FLOAT)
+                .Attr("index", 0)
                 .Attr("_ngraph_marked_for_clustering", true)
                 .Finalize(&g, &node1));
 
@@ -169,7 +166,5 @@ TEST(AssignClusters, Cone) {
 }
 
 }  // namespace testing
-
 }  // namespace ngraph_bridge
-
 }  // namespace tensorflow

--- a/test/graph_rewrites/deadness_test.cc
+++ b/test/graph_rewrites/deadness_test.cc
@@ -37,12 +37,9 @@
 
 #if !defined(NGRAPH_TF_DISABLE_DEADNESS_CHECK)
 using namespace std;
-namespace ng = ngraph;
 
 namespace tensorflow {
-
 namespace ngraph_bridge {
-
 namespace testing {
 
 /*******************************************************************************
@@ -160,7 +157,7 @@ TEST(DeadnessCheck, DTestG1) {
 
 // Graph 2
 //
-//               A1(#True)[Const]
+//               A1(#True)[Identity]
 //              /    \      \ 
 //             /      \      \ 
 //            /        \      \ 
@@ -182,7 +179,7 @@ TEST(DeadnessCheck, DTestG2) {
   auto SX = ops::Switch(root.WithOpName("SwitchX"), dataX, predX);
   auto SY = ops::Switch(root.WithOpName("SwitchY"), dataY, predY);
 
-  auto A1 = ops::Const(root.WithOpName("A1"), {3.f, 2.f});
+  auto A1 = ops::Identity(root.WithOpName("A1"), {1.0f});
   auto N1_Add = ops::Add(root.WithOpName("N1_Add"), SX.output_true, A1);
   auto N2_Sub = ops::Sub(root.WithOpName("N2_Sub"), SY.output_true, A1);
   auto N3_Mul = ops::Mul(root.WithOpName("N3_Mul"), N2_Sub, A1);
@@ -272,7 +269,7 @@ TEST(DeadnessCheck, DTestG3) {
 // Graph 4
 // Ops A1, N1 and N2 should be placed in the same cluster
 //
-// A1(#True)[Const]   B1(#True)[Const]
+// A1(#True)[Identity]   B1(#True)[Identity]
 //     \              /    \ 
 //      \            /      \ 
 //       \          /         \ 
@@ -282,68 +279,12 @@ TEST(DeadnessCheck, DTestG3) {
 //          /       \ 
 //  N2(#P1)[Add]   N3(#P1)[Mul]
 //
-// P1 is not supported on nGraph so is not clustered
-// There will be 3 clusters
-// Cluster 1: B1
-// Cluster 2: A1, N1, N2, N3
-// Cluster 3: N4
-// Disabling this test now. Its behaviour has changed and is captured in
-// DTestG4New
-TEST(DeadnessCheck, DISABLED_DTestG4) {
-  Scope root = Scope::NewRootScope();
-
-  auto dataX = ops::Placeholder(root.WithOpName("dataX"), DataType::DT_FLOAT);
-  auto predX = ops::Placeholder(root.WithOpName("PredX"), DataType::DT_BOOL);
-  auto SX = ops::Switch(root.WithOpName("SwitchX"), dataX, predX);
-  auto dataY = ops::Placeholder(root.WithOpName("dataY"), DataType::DT_FLOAT);
-  auto predY = ops::Placeholder(root.WithOpName("PredY"), DataType::DT_BOOL);
-  auto SY = ops::Switch(root.WithOpName("SwitchY"), dataY, predY);
-
-  auto A1 = ops::Const(root.WithOpName("A1"), {3.f, 2.f});
-  auto B1 = ops::Const(root.WithOpName("B1"), {3.f, 2.f});
-  auto N1_Add = ops::Add(root.WithOpName("N1_Add"), A1, B1);
-  auto N2_Add = ops::Add(root.WithOpName("N2_Add"), N1_Add, SX.output_false);
-  auto N3_Mul = ops::Mul(root.WithOpName("N3_Mul"), N1_Add, SX.output_false);
-  auto N4_Sub = ops::Sub(root.WithOpName("N4_Sub"), B1, SY.output_false);
-
-  std::set<string> skip_these_nodes = {};
-
-  Graph graph(OpRegistry::Global());
-  TF_CHECK_OK(root.ToGraph(&graph));
-  ASSERT_OK(MarkForClustering(&graph, skip_these_nodes));
-  ASSERT_OK(AssignClusters(&graph));
-
-  std::map<std::string, Node*> node_map;
-  for (auto node : graph.op_nodes()) {
-    node_map[node->name()] = node;
-  }
-
-  int N1_Add_cluster, N2_Add_cluster, A1_cluster, N3_Mul_cluster,
-      N4_Sub_cluster, B1_cluster;
-  ASSERT_OK(GetNodeCluster(node_map["A1"], &A1_cluster));
-  ASSERT_OK(GetNodeCluster(node_map["B1"], &B1_cluster));
-  ASSERT_OK(GetNodeCluster(node_map["N1_Add"], &N1_Add_cluster));
-  ASSERT_OK(GetNodeCluster(node_map["N2_Add"], &N2_Add_cluster));
-  ASSERT_OK(GetNodeCluster(node_map["N3_Mul"], &N3_Mul_cluster));
-  ASSERT_OK(GetNodeCluster(node_map["N4_Sub"], &N4_Sub_cluster));
-
-  // A1, N1, N2, N3 are in the same cluster
-  ASSERT_EQ(A1_cluster, N1_Add_cluster);
-  ASSERT_EQ(N2_Add_cluster, N3_Mul_cluster);
-  ASSERT_EQ(A1_cluster, N2_Add_cluster);
-
-  // A1, B1 and N4 are in different clusters
-  ASSERT_NE(A1_cluster, B1_cluster);
-  ASSERT_NE(A1_cluster, N4_Sub_cluster);
-  ASSERT_NE(B1_cluster, N4_Sub_cluster);
-}
-
 // There will be 4 clusters after the new change
 // Cluster 1: N2
 // Cluster 2: A1, N1, B1
 // Cluster 3: N3
 // Cluster 4: N4
-TEST(DeadnessCheck, DTestG4New) {
+TEST(DeadnessCheck, DTestG4) {
   Scope root = Scope::NewRootScope();
 
   auto dataX = ops::Placeholder(root.WithOpName("dataX"), DataType::DT_FLOAT);
@@ -353,8 +294,8 @@ TEST(DeadnessCheck, DTestG4New) {
   auto predY = ops::Placeholder(root.WithOpName("PredY"), DataType::DT_BOOL);
   auto SY = ops::Switch(root.WithOpName("SwitchY"), dataY, predY);
 
-  auto A1 = ops::Const(root.WithOpName("A1"), {3.f, 2.f});
-  auto B1 = ops::Const(root.WithOpName("B1"), {3.f, 2.f});
+  auto A1 = ops::Identity(root.WithOpName("A1"), {1.f});
+  auto B1 = ops::Identity(root.WithOpName("B1"), {1.f});
   auto N1_Add = ops::Add(root.WithOpName("N1_Add"), A1, B1);
   auto N2_Add = ops::Add(root.WithOpName("N2_Add"), N1_Add, SX.output_false);
   auto N3_Mul = ops::Mul(root.WithOpName("N3_Mul"), N1_Add, SX.output_false);
@@ -385,7 +326,7 @@ TEST(DeadnessCheck, DTestG4New) {
       int curr_node_cluster_id;
       ASSERT_OK(GetNodeCluster(node_map[group[i]], &curr_node_cluster_id));
       ASSERT_TRUE(curr_node_cluster_id == representative_group_id[group_id])
-          << "Group " << group_id << " (" << ng::join(group)
+          << "Group " << group_id << " (" << ngraph::join(group)
           << ") does not have all members in the same cluster. Expected "
              "cluster "
           << representative_group_id[group_id] << " got "
@@ -398,8 +339,8 @@ TEST(DeadnessCheck, DTestG4New) {
   for (int i = 0; i < num_groups; i++) {
     for (int j = i + 1; j < num_groups; j++) {
       ASSERT_TRUE(representative_group_id[i] != representative_group_id[j])
-          << " Group " << i << " (" << ng::join(arrangement_specs[i])
-          << ") and group " << j << " (" << ng::join(arrangement_specs[j])
+          << " Group " << i << " (" << ngraph::join(arrangement_specs[i])
+          << ") and group " << j << " (" << ngraph::join(arrangement_specs[j])
           << ") were assigned the same cluster " << representative_group_id[i];
     }
   }
@@ -409,7 +350,7 @@ TEST(DeadnessCheck, DTestG4New) {
 //            SX(#True)[Switch]      SY(#True)[Switch]
 //                   \                   /  \ 
 //                    \(X)          (~Y)/    \(Y)
-//  A(#True)[Const]    \-> N1(X & ~Y)[Add]   N5(Y)[Add]<----- B(#True)[Pl]
+//  A(#True)[Identity] \-> N1(X & ~Y)[Add]   N5(Y)[Add]<----- B(#True)[Const]
 //         \                   |                |              |
 //          \                  |                |              |
 //           \----------->N2(X & ~Y)[Mul]    N6(Y)[Mul]<-------|
@@ -439,7 +380,7 @@ TEST(DeadnessCheck, DTestG5) {
   auto SY = ops::Switch(root.WithOpName("SwitchY"), dataY, predY);
   auto SZ = ops::Switch(root.WithOpName("SwitchZ"), dataZ, predZ);
 
-  auto A = ops::Const(root.WithOpName("A"), {3.f, 2.f});
+  auto A = ops::Identity(root.WithOpName("A"), {1.f});
   auto B = ops::Const(root.WithOpName("B"), {3.f, 2.f});
   auto N1_Add =
       ops::Add(root.WithOpName("N1_Add"), SX.output_true, SY.output_false);

--- a/test/models/tf_ov_model_zoo/models_cpu.txt
+++ b/test/models/tf_ov_model_zoo/models_cpu.txt
@@ -20,7 +20,7 @@ vgg_19  bike  'tricycle, trike, velocipede\s*( 10.'
 densenet_121  bike  'mountain bike, all-terrain bike, off-roader\s*( 0.6'
 densenet_169  bike  'mountain bike, all-terrain bike, off-roader\s*( 0.8'
 densenet_201  bike  'mountain bike, all-terrain bike, off-roader\s*( 0.7'
-# fc_densenet_103  bike  '.*'
+fc_densenet_103  bike  '.*'
 
 mobilenet_v1  bike  '.*'
 mobilenet_v2  bike  '.*'


### PR DESCRIPTION
* Enable FC-DenseNet 103 model in the CPU pipeline
* Remove static input constraint for Shape op
* Deassign Const nodes with outputs to another cluster to avoid Const->Result patterns in nGraph function
