### PR TITLE
Enable shape information for nGraph graphs

### DIFF
--- a/ngraph_bridge/ngraph_utils.cc
+++ b/ngraph_bridge/ngraph_utils.cc
@@ -420,6 +420,10 @@ void DumpGraphs(const GraphOptimizationPassOptions& options, int idx,
       sub_idx++;
     }
   }
+  // enable shape info for nGraph graphs
+  SetEnv("NGRAPH_VISUALIZE_TREE_OUTPUT_SHAPES", "1");
+  SetEnv("NGRAPH_VISUALIZE_TREE_OUTPUT_TYPES", "1");
+  SetEnv("NGRAPH_VISUALIZE_TREE_IO", "1");
 }
 
 bool DumpAllGraphs() { return GetEnv("TF_OV_DUMP_GRAPHS") == "1"; }
@@ -450,6 +454,8 @@ string GetEnv(const char* env) {
     return string(val);
   }
 }
+
+void SetEnv(const char* env, const char* val) { setenv(env, val, 1); }
 
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_utils.h
+++ b/ngraph_bridge/ngraph_utils.h
@@ -345,6 +345,8 @@ bool DumpAllGraphs();
 
 string GetEnv(const char* env);
 
+void SetEnv(const char* env, const char* val);
+
 }  // namespace ngraph_bridge
 }  // namespace tensorflow
 


### PR DESCRIPTION
Enable shape info for nGraph graphs when dumping those by setting the env variables in the code
"NGRAPH_VISUALIZE_TREE_OUTPUT_SHAPES"
"NGRAPH_VISUALIZE_TREE_OUTPUT_TYPES"
 "NGRAPH_VISUALIZE_TREE_IO"