### PR TITLE
Remove executable caching in backend

### DIFF
--- a/ngraph_bridge/backend.h
+++ b/ngraph_bridge/backend.h
@@ -32,40 +32,13 @@ namespace ngraph_bridge {
 class Backend {
  public:
   Backend(const string& configuration_string);
-  ~Backend();
+  ~Backend() {}
 
   shared_ptr<Executable> compile(shared_ptr<ngraph::Function> func,
                                  bool enable_performance_data = false);
-  void remove_compiled_function(std::shared_ptr<Executable> exec);
   bool is_supported(const ngraph::Node& node) const;
 
-  shared_ptr<ngraph::runtime::Tensor> create_dynamic_tensor(
-      const ngraph::element::Type& type, const ngraph::PartialShape& shape);
-
-  static vector<string> get_registered_devices();
-
-  shared_ptr<ngraph::runtime::Tensor> create_tensor(
-      const ngraph::element::Type& element_type, const ngraph::Shape& shape);
-
-  shared_ptr<ngraph::runtime::Tensor> create_tensor(
-      const ngraph::element::Type& element_type, const ngraph::Shape& shape,
-      void* data);
-
-  template <typename T>
-  shared_ptr<ngraph::runtime::Tensor> create_tensor(ngraph::element::Type type,
-                                                    ngraph::Shape shape,
-                                                    T* data) {
-    auto tensor = make_shared<IETensor>(type, shape);
-    size_t size = shape_size(shape);
-    tensor->write(data, size * sizeof(T));
-    return tensor;
-  }
-
  private:
-  std::mutex m_exec_map_mutex;
-  std::unordered_map<std::shared_ptr<ngraph::Function>,
-                     std::shared_ptr<Executable>>
-      m_exec_map;
   string m_device;
 };
 }

--- a/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
@@ -301,9 +301,8 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ctx, ng_element_type == expected_elem_type,
         errors::Internal("Element type inferred by nGraph does not match "
                          "the element type expected by TensorFlow"));
-    ng_outputs[i] = make_shared<IETensor>(ng_element_type, ng_shape);
-    size_t size = shape_size(ng_shape);
-    ng_outputs[i]->write(output_tensor->data(), size * sizeof(void*));
+    ng_outputs[i] =
+        make_shared<IETensor>(ng_element_type, ng_shape, output_tensor->data());
   }
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute allocated result tensors for cluster "

--- a/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
@@ -254,8 +254,8 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
 
       auto backend = BackendManager::GetBackend();
       std::shared_ptr<ngraph::runtime::Tensor> ng_tensor =
-          backend->create_tensor(ng_element_type, ng_shape,
-                                 tf_input_tensors[i].data());
+          make_shared<IETensor>(ng_element_type, ng_shape,
+                                tf_input_tensors[i].data());
       ng_inputs.push_back(ng_tensor);
     }
   }
@@ -301,8 +301,9 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ctx, ng_element_type == expected_elem_type,
         errors::Internal("Element type inferred by nGraph does not match "
                          "the element type expected by TensorFlow"));
-    ng_outputs[i] =
-        make_shared<IETensor>(ng_element_type, ng_shape, output_tensor->data());
+    ng_outputs[i] = make_shared<IETensor>(ng_element_type, ng_shape);
+    size_t size = shape_size(ng_shape);
+    ng_outputs[i]->write(output_tensor->data(), size * sizeof(void*));
   }
   NGRAPH_VLOG(4)
       << "NGraphEncapsulateOp::Compute allocated result tensors for cluster "
@@ -433,9 +434,6 @@ Status NGraphEncapsulateOp::GetExecutable(
     if (m_ng_exec_map.size() >= m_function_cache_depth_in_items) {
       evicted_ng_exec = m_ng_exec_map[m_lru.back()];
       m_ng_exec_map.erase(m_lru.back());
-
-      // Call delete function here for the erased func
-      backend->remove_compiled_function(evicted_ng_exec);
 
       m_lru.pop_back();
     }  // cache eviction if cache size greater than cache depth

--- a/ngraph_bridge/ngraph_backend_manager.cc
+++ b/ngraph_bridge/ngraph_backend_manager.cc
@@ -97,7 +97,8 @@ Status BackendManager::CreateBackend(shared_ptr<Backend>& backend,
 
 // Returns the nGraph supported backend names
 vector<string> BackendManager::GetSupportedBackends() {
-  return Backend::get_registered_devices();
+  InferenceEngine::Core core;
+  return core.GetAvailableDevices();
 }
 
 }  // namespace ngraph_bridge

--- a/test/test_ngraph_exec.cpp
+++ b/test/test_ngraph_exec.cpp
@@ -166,11 +166,11 @@ TEST_F(NGraphExecTest, Axpy) {
     ng_shape_y[i] = y.shape().dim_size(i);
   }
 
-  auto t_x = backend->create_tensor(ng::element::f32, ng_shape_x);
+  auto t_x = make_shared<IETensor>(ng::element::f32, ng_shape_x);
   float v_x[2][3] = {{1, 1, 1}, {1, 1, 1}};
   t_x->write(&v_x, sizeof(v_x));
 
-  auto t_y = backend->create_tensor(ng::element::f32, ng_shape_y);
+  auto t_y = make_shared<IETensor>(ng::element::f32, ng_shape_y);
   t_y->write(&v_x, sizeof(v_x));
 
   // Execute the nGraph function.
@@ -221,11 +221,11 @@ TEST_F(NGraphExecTest, Axpy8bit) {
     ng_shape_y[i] = y.shape().dim_size(i);
   }
 
-  auto t_x = backend->create_tensor(ng::element::i8, ng_shape_x);
+  auto t_x = make_shared<IETensor>(ng::element::i8, ng_shape_x);
   int8 v_x[2][2] = {{1, 1}, {1, 1}};
   t_x->write(&v_x, sizeof(v_x));
 
-  auto t_y = backend->create_tensor(ng::element::i8, ng_shape_y);
+  auto t_y = make_shared<IETensor>(ng::element::i8, ng_shape_y);
   t_y->write(&v_x, sizeof(v_x));
 
   // Execute the nGraph function.


### PR DESCRIPTION
* Remove executable caching in backend because it is already done by the executor
* Remove other unused interfaces in backend