### PR TITLE
Exclude headers from the generated python wheel

### DIFF
--- a/python/CreatePipWhl.cmake
+++ b/python/CreatePipWhl.cmake
@@ -47,11 +47,6 @@ if (PYTHON)
     file(GLOB NGRAPH_LIB_FILES "${NGTF_INSTALL_DIR}/${LIB_SUFFIX}/*")
     # Copy the ngraph_bridge include from install
     message(STATUS "NGTF_INSTALL_DIR: ${NGTF_INSTALL_DIR}")
-    
-    file(
-        COPY "${NGRAPH_INSTALL_DIR}/include" 
-        DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge"
-    )
 
     # Copy the ngraph_bridge libraries from install
     foreach(DEP_FILE ${NGRAPH_LIB_FILES})

--- a/python/setup.in.py
+++ b/python/setup.in.py
@@ -37,25 +37,15 @@ ext = 'dylib' if system() == 'Darwin' else 'so'
 with open(@README_DOC@, "r") as fh:
     long_description = fh.read()
 
-# Collect the list of include files, while preserving the tree structure
-os.chdir('ngraph_bridge')
-include_list = []
-for path, dirs, files in os.walk('include'):
-  for f in files:
-    include_list.append(path + "/" + f )
-
-os.chdir('..')
-
 # The following is filled in my cmake - essentially a list of library
 # and license files
 ng_data_list = [
     @ngraph_libraries@ @license_files@ @licence_top_level@
 ]
-include_list.extend(ng_data_list)
 
 # This is the contents of the Package Data
 package_data_dict = {}
-package_data_dict['ngraph_bridge'] = include_list
+package_data_dict['ngraph_bridge'] = ng_data_list
 
 setup(
     name='ngraph_tensorflow_bridge',


### PR DESCRIPTION
Avoid copying OV/nGraph headers into the wheel