### PR TITLE
Follow a consistent naming scheme when dumping graphs

### DIFF
--- a/ngraph_bridge/executable.cc
+++ b/ngraph_bridge/executable.cc
@@ -59,7 +59,7 @@ Executable::Executable(shared_ptr<Function> func, string device)
   }
   if (parameters.size() != used_parameters.size()) {
     func = make_shared<Function>(func->get_results(), used_parameters,
-                                 func->get_name());
+                                 func->get_friendly_name());
   }
 
   // A trivial function is one of
@@ -103,8 +103,9 @@ Executable::Executable(shared_ptr<Function> func, string device)
         ngraph::replace_node(node, param);
         // nGraph doesn't provide a way to set a parameter to an existing
         // function, so we clone the function here...
-        func = make_shared<Function>(func->get_results(),
-                                     ParameterVector{param}, func->get_name());
+        func =
+            make_shared<Function>(func->get_results(), ParameterVector{param},
+                                  func->get_friendly_name());
         auto ie_tensor = make_shared<IETensor>(element_type, shape);
         ie_tensor->write(constant->get_data_ptr(),
                          shape_size(shape) * element_type.size());
@@ -131,11 +132,11 @@ Executable::Executable(shared_ptr<Function> func, string device)
   std::map<string, string> options;
 
   if (util::DumpAllGraphs()) {
-    auto& name = m_network.getName();
+    auto& name = m_function->get_friendly_name();
     m_network.serialize(name + ".xml", name + ".bin");
-    util::DumpNGGraph(func, "tf_function_" + name + "_ie");
+    util::DumpNGGraph(func, name + "_executable");
     options[InferenceEngine::PluginConfigParams::KEY_DUMP_EXEC_GRAPH_AS_DOT] =
-        "ie_" + m_device + "_" + name;
+        name + "_IE_" + m_device;
   }
 
   NGRAPH_VLOG(2) << "Loading IE CNN network to device " << m_device;

--- a/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
+++ b/ngraph_bridge/kernels/ngraph_encapsulate_op.cc
@@ -414,9 +414,8 @@ Status NGraphEncapsulateOp::GetExecutable(
 
     NGRAPH_VLOG(1) << "Compilation cache miss: " << m_name;
     TF_RETURN_IF_ERROR(Builder::TranslateGraph(input_shapes, static_input_map,
-                                               &m_graph, ng_function));
-    ng_function->set_friendly_name(m_name);
-    util::DumpNGGraph(ng_function, "tf_function_" + m_name);
+                                               &m_graph, m_name, ng_function));
+    util::DumpNGGraph(ng_function, m_name);
 
     // Evict the cache if the number of elements exceeds the limit
     std::shared_ptr<Executable> evicted_ng_exec;

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -2736,7 +2736,8 @@ const static std::map<
 Status Builder::TranslateGraph(
     const std::vector<TensorShape>& inputs,
     const std::vector<const Tensor*>& static_input_map,
-    const Graph* input_graph, shared_ptr<ng::Function>& ng_function) {
+    const Graph* input_graph, const string name,
+    shared_ptr<ng::Function>& ng_function) {
   //
   // We will visit ops in topological order.
   //
@@ -2870,7 +2871,8 @@ Status Builder::TranslateGraph(
   //
   // Create the nGraph function.
   //
-  ng_function = make_shared<ng::Function>(ng_result_list, ng_parameter_list);
+  ng_function =
+      make_shared<ng::Function>(ng_result_list, ng_parameter_list, name);
 
   //
   // Apply additional passes on the nGraph function here.

--- a/ngraph_bridge/ngraph_builder.h
+++ b/ngraph_bridge/ngraph_builder.h
@@ -32,7 +32,7 @@ class Builder {
   static Status TranslateGraph(
       const std::vector<TensorShape>& inputs,
       const std::vector<const Tensor*>& static_input_map, const Graph* tf_graph,
-      std::shared_ptr<ngraph::Function>& ng_function);
+      const string name, std::shared_ptr<ngraph::Function>& ng_function);
 
   using OpMap = std::unordered_map<std::string,
                                    std::vector<ngraph::Output<ngraph::Node>>>;

--- a/ngraph_bridge/ngraph_utils.cc
+++ b/ngraph_bridge/ngraph_utils.cc
@@ -223,30 +223,29 @@ void MemoryProfile(long& vm_usage, long& resident_set) {
   }
 }
 
-void DumpTFGraph(tensorflow::Graph* graph, int idx,
-                 std::string filename_prefix) {
+void DumpTFGraph(tensorflow::Graph* graph, int idx, std::string filename) {
   if (!DumpAllGraphs()) {
     return;
   }
 
   std::stringstream ss;
-  ss << filename_prefix << "_" << std::setfill('0') << std::setw(4) << idx;
-  auto filename = ss.str() + ".pbtxt";
-  NGRAPH_VLOG(0) << "Dumping graph to " << filename;
-  GraphToPbTextFile(graph, filename);
+  ss << filename << "_" << std::setfill('0') << std::setw(4) << idx;
+  NGRAPH_VLOG(0) << "Dumping TF graph to " << ss.str() + ".pbtxt";
+  GraphToPbTextFile(graph, ss.str() + ".pbtxt");
 }
 
 void DumpNGGraph(std::shared_ptr<ngraph::Function> function,
-                 const string filename_prefix) {
+                 const string filename) {
   if (!DumpAllGraphs()) {
     return;
   }
 
+  NGRAPH_VLOG(0) << "Dumping nGraph graph to " << filename + ".dot";
   // enable shape info for nGraph graphs
   SetEnv("NGRAPH_VISUALIZE_TREE_OUTPUT_SHAPES", "1");
   SetEnv("NGRAPH_VISUALIZE_TREE_OUTPUT_TYPES", "1");
   SetEnv("NGRAPH_VISUALIZE_TREE_IO", "1");
-  ngraph::plot_graph(function, filename_prefix + ".dot");
+  ngraph::plot_graph(function, filename + ".dot");
 }
 
 bool DumpAllGraphs() { return GetEnv("TF_OV_DUMP_GRAPHS") == "1"; }

--- a/ngraph_bridge/pass/transpose_sinking.cc
+++ b/ngraph_bridge/pass/transpose_sinking.cc
@@ -437,10 +437,7 @@ bool TransposeSinking::run_on_function(shared_ptr<ngraph::Function> f) {
   unordered_map<std::string, ngraph::Shape> orig_result_out_shape;
 
   if (util::DumpAllGraphs()) {
-    NGRAPH_VLOG(0)
-        << "Dumping nGraph function before TransposeSinking to before_TS_"
-        << f->get_name() << ".dot";
-    util::DumpNGGraph(f, "before_TS_" + f->get_name());
+    util::DumpNGGraph(f, f->get_friendly_name() + "_before_TS");
   }
 
   // STEP 1 : Sink or Swim transposes away for op clusters
@@ -493,10 +490,7 @@ bool TransposeSinking::run_on_function(shared_ptr<ngraph::Function> f) {
   }
 
   if (util::DumpAllGraphs()) {
-    NGRAPH_VLOG(0)
-        << "Dumping nGraph function after TransposeSinking to after_TS_"
-        << f->get_name() << ".dot";
-    util::DumpNGGraph(f, "after_TS_" + f->get_name());
+    util::DumpNGGraph(f, f->get_friendly_name() + "_after_TS");
   }
   return true;
 }

--- a/test/test_ngraph_exec.cpp
+++ b/test/test_ngraph_exec.cpp
@@ -76,7 +76,8 @@ class NGraphExecTest : public ::testing::Test {
     std::vector<const Tensor*> static_input_map(tf_input_shapes.size(),
                                                 nullptr);
     TF_RETURN_IF_ERROR(ngraph_bridge::Builder::TranslateGraph(
-        tf_input_shapes, static_input_map, &input_graph, "test_ngraph_exec", ng_function));
+        tf_input_shapes, static_input_map, &input_graph, "test_ngraph_exec",
+        ng_function));
     return Status::OK();
   }
 

--- a/test/test_ngraph_exec.cpp
+++ b/test/test_ngraph_exec.cpp
@@ -76,7 +76,7 @@ class NGraphExecTest : public ::testing::Test {
     std::vector<const Tensor*> static_input_map(tf_input_shapes.size(),
                                                 nullptr);
     TF_RETURN_IF_ERROR(ngraph_bridge::Builder::TranslateGraph(
-        tf_input_shapes, static_input_map, &input_graph, ng_function));
+        tf_input_shapes, static_input_map, &input_graph, "test_ngraph_exec", ng_function));
     return Status::OK();
   }
 


### PR DESCRIPTION
When TF_OV_DUMP_GRAPHS=1 graphs at various different stages in the
pipeline are dumped. We follow a consistent naming scheme for graphs as
shown below:

nGraph graph:
`ngraph_cluster_226.dot`

nGraph graphs during optimization passes:
`ngraph_cluster_226_before_TS.dot`
`ngraph_cluster_226_after_TS.dot`

nGraph graph after an executable is built:
`ngraph_cluster_226_executable.dot`

IE CNN network:
`ngraph_cluster_226.xml`
`ngraph_cluster_226.bin`

IE CNN network after it's loaded to a device:
`ngraph_cluster_226_IE_CPU_init.dot`