### PR TITLE
Run OV models correctly for benchmarking pipelines

### DIFF
--- a/test/models/tf_ov_model_zoo/run_infer_single.sh
+++ b/test/models/tf_ov_model_zoo/run_infer_single.sh
@@ -163,6 +163,7 @@ function run_bench_stockov {
     [ -d $VENVTMP ] && rm -rf $VENVTMP
     virtualenv -p python3 $VENVTMP
     source $VENVTMP/bin/activate
+    pip_install opencv-python
 
     cd ${LOCALSTORE}/demo
     TMPFILE=${WORKDIR}/tmp_output$$

--- a/test/models/tf_ov_model_zoo/run_infer_single.sh
+++ b/test/models/tf_ov_model_zoo/run_infer_single.sh
@@ -164,11 +164,13 @@ function run_bench_stockov {
     virtualenv -p python3 $VENVTMP
     source $VENVTMP/bin/activate
     pip_install opencv-python
+    pip_install openvino==2021.2
 
     cd ${LOCALSTORE}/demo
     TMPFILE=${WORKDIR}/tmp_output$$
-    . ${INTEL_OPENVINO_DIR}/bin/setupvars.sh
-    ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
+    pythonlib=$(echo $(dirname $(which python3))/../lib)
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonlib:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64/ \ 
+        ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
     ret_code=$?
     if (( $ret_code == 0 )); then
         echo

--- a/test/models/tf_ov_model_zoo/run_infer_single.sh
+++ b/test/models/tf_ov_model_zoo/run_infer_single.sh
@@ -167,10 +167,8 @@ function run_bench_stockov {
 
     cd ${LOCALSTORE}/demo
     TMPFILE=${WORKDIR}/tmp_output$$
-    pythonlib=$(echo $(dirname $(which python3))/../lib)
-    echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonlib ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonlib:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64/ \
-        ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
+    . ${INTEL_OPENVINO_DIR}/bin/setupvars.sh
+    ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
     ret_code=$?
     if (( $ret_code == 0 )); then
         echo

--- a/test/models/tf_ov_model_zoo/run_infer_single.sh
+++ b/test/models/tf_ov_model_zoo/run_infer_single.sh
@@ -168,8 +168,7 @@ function run_bench_stockov {
 
     cd ${LOCALSTORE}/demo
     TMPFILE=${WORKDIR}/tmp_output$$
-    pythonlib=$(echo $(dirname $(which python3))/../lib)
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$pythonlib:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64/ \ 
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64 \
         ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
     ret_code=$?
     if (( $ret_code == 0 )); then

--- a/test/models/tf_ov_model_zoo/run_infer_single.sh
+++ b/test/models/tf_ov_model_zoo/run_infer_single.sh
@@ -168,7 +168,8 @@ function run_bench_stockov {
 
     cd ${LOCALSTORE}/demo
     TMPFILE=${WORKDIR}/tmp_output$$
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64 \
+    pythonlib=$(echo $(dirname $(which python3))/../lib)
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/lib/intel64:$pythonlib \
         ./run_ov_infer.sh ${MODEL} ${IMGFILE} $NUM_ITER $device 2>&1 > ${TMPFILE}
     ret_code=$?
     if (( $ret_code == 0 )); then


### PR DESCRIPTION
Set library path correctly to find plugins not included in the openvino pip package when running OV models for benchmarking pipelines.