### PR TITLE
Refactoring to separate TF and nGraph APIs

### DIFF
--- a/examples/cpp/infer_multiple_networks.cc
+++ b/examples/cpp/infer_multiple_networks.cc
@@ -35,7 +35,6 @@
 
 #include "ngraph_bridge/backend_manager.h"
 #include "ngraph_bridge/timer.h"
-#include "ngraph_bridge/utils.h"
 #include "ngraph_bridge/version.h"
 
 #include "inference_engine.h"
@@ -60,15 +59,6 @@ void PrintAvailableBackends() {
   for (auto& backend_name : backends) {
     cout << "Backend: " << backend_name << std::endl;
   }
-}
-
-// Sets the specified backend. This backend must be set BEFORE running
-// the computation
-tf::Status SetNGraphBackend(const string& backend_name) {
-  // Select a backend
-  tf::Status status =
-      tf::ngraph_bridge::BackendManager::SetBackend(backend_name);
-  return status;
 }
 
 void PrintVersion() {
@@ -158,12 +148,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  const char* backend = "CPU";
-  if (SetNGraphBackend(backend) != tf::Status::OK()) {
-    std::cout << "Error: Cannot set the backend: " << backend << std::endl;
-    return -1;
-  }
-
   std::cout << "Component versions\n";
   PrintVersion();
 
@@ -194,27 +178,23 @@ int main(int argc, char** argv) {
   TF_CHECK_OK(benchmark::InferenceEngine::CreateSession(graph, session_three));
   session_db[session_three.get()] = "Three";
   std::vector<Tensor> outputs;
-  {
-    NG_TRACE("Compilation", "Compilation", "");
-
-    //
-    // Warm-up i.e., Call it onces to get the nGraph compilation done
-    //
-    Tensor next_image;
-    TF_CHECK_OK(inference_engine.GetNextImage(next_image));
-    // Run inference once. This will trigger a compilation
-    tf::ngraph_bridge::Timer compilation_time;
-    TF_CHECK_OK(session_one->Run({{input_layer, next_image}}, {output_layer},
+  //
+  // Warm-up i.e., Call it onces to get the nGraph compilation done
+  //
+  Tensor next_image;
+  TF_CHECK_OK(inference_engine.GetNextImage(next_image));
+  // Run inference once. This will trigger a compilation
+  tf::ngraph_bridge::Timer compilation_time;
+  TF_CHECK_OK(session_one->Run({{input_layer, next_image}}, {output_layer}, {},
+                               &outputs));
+  TF_CHECK_OK(session_two->Run({{input_layer, next_image}}, {output_layer}, {},
+                               &outputs));
+  TF_CHECK_OK(session_three->Run({{input_layer, next_image}}, {output_layer},
                                  {}, &outputs));
-    TF_CHECK_OK(session_two->Run({{input_layer, next_image}}, {output_layer},
-                                 {}, &outputs));
-    TF_CHECK_OK(session_three->Run({{input_layer, next_image}}, {output_layer},
-                                   {}, &outputs));
-    compilation_time.Stop();
+  compilation_time.Stop();
 
-    cout << "Compilation took: " << compilation_time.ElapsedInMS() << " ms"
-         << endl;
-  }
+  cout << "Compilation took: " << compilation_time.ElapsedInMS() << " ms"
+       << endl;
   //
   // Add these sessions to the queue
   //
@@ -241,8 +221,6 @@ int main(int argc, char** argv) {
     // Run the inference loop
     //-----------------------------------------
     for (int i = 0; i < iteration_count; i++) {
-      NG_TRACE(oss.str(), to_string(i), "");
-
       tf::ngraph_bridge::Timer get_image_timer;
       //
       // Get the image
@@ -255,21 +233,15 @@ int main(int argc, char** argv) {
       // Get the next available network model (i.e., session)
       //
       tf::ngraph_bridge::Timer execute_inference_timer;
-      unique_ptr<Session> next_available_session;
-      {
-        NG_TRACE("Get Session", string("Iteration") + to_string(i), "");
-        next_available_session = session_queue.GetNextAvailable();
-      }
+      unique_ptr<Session> next_available_session =
+          session_queue.GetNextAvailable();
 
       //
       // Run inference on this network model (i.e., session)
       //
-      {
-        NG_TRACE("Run Session", string("Iteration") + to_string(i), "");
-        TF_CHECK_OK(next_available_session->Run({{input_layer, next_image}},
-                                                {output_layer}, {},
-                                                &output_each_thread));
-      }
+      TF_CHECK_OK(next_available_session->Run({{input_layer, next_image}},
+                                              {output_layer}, {},
+                                              &output_each_thread));
       Session* next_session_ptr = next_available_session.get();
       session_queue.Add(move(next_available_session));
       execute_inference_timer.Stop();

--- a/examples/cpp/infer_single_network.cc
+++ b/examples/cpp/infer_single_network.cc
@@ -35,7 +35,6 @@
 #include "inference_engine.h"
 #include "ngraph_bridge/backend_manager.h"
 #include "ngraph_bridge/timer.h"
-#include "ngraph_bridge/utils.h"
 #include "ngraph_bridge/version.h"
 
 using namespace std;
@@ -163,20 +162,16 @@ int main(int argc, char** argv) {
 
   Tensor next_image;
   std::vector<Tensor> outputs;
-  {
-    NG_TRACE("Compilation", "Compilation", "");
+  // Call it onces to get the nGraph compilation done
+  TF_CHECK_OK(inference_engine.GetNextImage(next_image));
+  // Run inference once. This will trigger a compilation
+  tf::ngraph_bridge::Timer compilation_time;
+  TF_CHECK_OK(the_session->Run({{input_layer, next_image}}, {output_layer}, {},
+                               &outputs));
+  compilation_time.Stop();
 
-    // Call it onces to get the nGraph compilation done
-    TF_CHECK_OK(inference_engine.GetNextImage(next_image));
-    // Run inference once. This will trigger a compilation
-    tf::ngraph_bridge::Timer compilation_time;
-    TF_CHECK_OK(the_session->Run({{input_layer, next_image}}, {output_layer},
-                                 {}, &outputs));
-    compilation_time.Stop();
-
-    cout << "Compilation took: " << compilation_time.ElapsedInMS() << " ms"
-         << endl;
-  }
+  cout << "Compilation took: " << compilation_time.ElapsedInMS() << " ms"
+       << endl;
 
   atomic<int> total_time_in_ms{0};
   atomic<int> total_images_processed{0};
@@ -185,7 +180,6 @@ int main(int argc, char** argv) {
     ostringstream oss;
     oss << "Worker_" << worker_id;
     for (int i = 0; i < iteration_count; i++) {
-      NG_TRACE(oss.str(), to_string(i), "");
       tf::ngraph_bridge::Timer iteration_timer;
       // Get the image
       Tensor next_image;

--- a/ngraph_bridge/CMakeLists.txt
+++ b/ngraph_bridge/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SRC
    pass/transpose_sinking.cc
    tf_graphcycles.cc
    tf_deadness_analysis.cc
+   tf_utils.cc
    utils.cc
    version.cc
 )

--- a/ngraph_bridge/api.cc
+++ b/ngraph_bridge/api.cc
@@ -76,12 +76,19 @@ bool IsEnabled() { return _is_enabled; }
 vector<string> ListBackends() { return BackendManager::GetSupportedBackends(); }
 
 bool SetBackend(const string& type) {
-  return (BackendManager::SetBackend(type) == Status::OK());
+  try {
+    BackendManager::SetBackend(type);
+  } catch (...) {
+    return false;
+  }
+  return true;
 }
 
 string GetBackend() {
   string backend;
-  if (BackendManager::GetBackendName(backend) != Status::OK()) {
+  try {
+    BackendManager::GetBackendName(backend);
+  } catch (...) {
     return "";
   }
   return backend;

--- a/ngraph_bridge/api.cc
+++ b/ngraph_bridge/api.cc
@@ -87,7 +87,7 @@ bool SetBackend(const string& type) {
 string GetBackend() {
   try {
     auto backend = BackendManager::GetBackend();
-    return backend->name();
+    return backend->Name();
   } catch (...) {
     return "";
   }

--- a/ngraph_bridge/api.cc
+++ b/ngraph_bridge/api.cc
@@ -85,13 +85,12 @@ bool SetBackend(const string& type) {
 }
 
 string GetBackend() {
-  string backend;
   try {
-    BackendManager::GetBackendName(backend);
+    auto backend = BackendManager::GetBackend();
+    return backend->name();
   } catch (...) {
     return "";
   }
-  return backend;
 }
 
 void StartLoggingPlacement() { _is_logging_placement = true; }

--- a/ngraph_bridge/api.h
+++ b/ngraph_bridge/api.h
@@ -58,7 +58,7 @@ extern void StartLoggingPlacement();
 extern void StopLoggingPlacement();
 extern bool IsLoggingPlacement();
 
-__attribute((abi_tag("cxx11"))) extern std::set<string> GetDisabledOps();
+extern std::set<string> GetDisabledOps();
 
 extern void SetDisabledOps(std::set<string>);
 extern void SetDisabledOps(string);

--- a/ngraph_bridge/api.h
+++ b/ngraph_bridge/api.h
@@ -58,7 +58,8 @@ extern void StartLoggingPlacement();
 extern void StopLoggingPlacement();
 extern bool IsLoggingPlacement();
 
-extern std::set<string> GetDisabledOps();
+__attribute((abi_tag("cxx11"))) extern std::set<string> GetDisabledOps();
+
 extern void SetDisabledOps(std::set<string>);
 extern void SetDisabledOps(string);
 

--- a/ngraph_bridge/assign_clusters.cc
+++ b/ngraph_bridge/assign_clusters.cc
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include "tensorflow/core/framework/attr_value_util.h"
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/node_def_util.h"
@@ -33,7 +35,6 @@
 #include "mark_for_clustering.h"
 #include "tf_deadness_analysis.h"
 #include "tf_graphcycles.h"
-#include "utils.h"
 
 using namespace std;
 
@@ -650,7 +651,8 @@ Status AssignClusters(Graph* graph) {
            "assigned an encapsulate)\n";
     for (auto it : cluster_separation_reason) {
       num_non_contracted += it.second.size();
-      auto cluster_id_vector = ngraph::split(it.first, ',');
+      std::vector<std::string> cluster_id_vector =
+          absl::StrSplit(it.first, ',');
       // function to find if this cluster became an ngraph_cluster
       // returns ngraph_cluster id if yes, else returns -1
       auto find_in_map = [&cluster_to_encapsulate, &cluster_id_vector](int x) {
@@ -688,7 +690,7 @@ Status AssignClusters(Graph* graph) {
                  to_string(dst_encapsulate) + "] predicate: " +
                  std::get<1>(deadness_predicates_tpl) +
                  " Neighbours predicates: " +
-                 ngraph::join(std::get<2>(deadness_predicates_tpl)) + "\n");
+                 absl::StrJoin(std::get<2>(deadness_predicates_tpl), "\n"));
           }
         }
         reason_count_clusters[inner_itr]++;

--- a/ngraph_bridge/backend.cc
+++ b/ngraph_bridge/backend.cc
@@ -14,12 +14,12 @@
 // limitations under the License.
 //*****************************************************************************
 
+#include <ie_core.hpp>
+#include "ngraph/ngraph.hpp"
+
 #include "backend.h"
 #include "default_opset.h"
 #include "log.h"
-
-#include <ie_core.hpp>
-#include "ngraph/ngraph.hpp"
 
 using namespace std;
 using namespace ngraph;

--- a/ngraph_bridge/backend.cc
+++ b/ngraph_bridge/backend.cc
@@ -15,6 +15,8 @@
 //*****************************************************************************
 
 #include "backend.h"
+#include "default_opset.h"
+#include "log.h"
 
 #include <ie_core.hpp>
 #include "ngraph/ngraph.hpp"
@@ -43,12 +45,190 @@ shared_ptr<Executable> Backend::Compile(shared_ptr<ngraph::Function> func,
   return make_shared<Executable>(func, m_device);
 }
 
-bool Backend::IsSupported(const Node& node) const {
-  // TODO: check if the given backend/device supports the op. Right now we're
-  // assuming
-  // that the selected backend supports all opset5 ops
+static std::map<std::string, std::set<shared_ptr<ngraph::Node>>>
+    TFtoNgraphOpMap{
+        {"Abs", {std::make_shared<opset::Abs>()}},
+        {"Acos", {std::make_shared<opset::Acos>()}},
+        {"Acosh", {std::make_shared<opset::Acosh>()}},
+        {"Add", {std::make_shared<opset::Add>()}},
+        {"AddN", {std::make_shared<opset::Add>()}},
+        {"AddV2", {std::make_shared<opset::Add>()}},
+        {"Any", {std::make_shared<opset::ReduceLogicalOr>()}},
+        {"All", {std::make_shared<opset::ReduceLogicalAnd>()}},
+        {"ArgMax",
+         {std::make_shared<opset::TopK>(), std::make_shared<opset::Squeeze>()}},
+        {"ArgMin",
+         {std::make_shared<opset::TopK>(), std::make_shared<opset::Squeeze>()}},
+        {"Asin", {std::make_shared<opset::Asin>()}},
+        {"Asinh", {std::make_shared<opset::Asinh>()}},
+        {"Atan", {std::make_shared<opset::Atan>()}},
+        {"Atanh", {std::make_shared<opset::Atanh>()}},
+        {"AvgPool", {std::make_shared<opset::AvgPool>()}},
+        {"BiasAdd",
+         {std::make_shared<opset::Add>(), std::make_shared<opset::Reshape>()}},
+        {"Cast", {std::make_shared<opset::Convert>()}},
+        {"Ceil", {std::make_shared<opset::Ceiling>()}},
+        {"ConcatV2", {std::make_shared<opset::Concat>()}},
+        {"Const", {}},
+        {"Conv2D",
+         {std::make_shared<opset::Transpose>(),
+          std::make_shared<opset::Convolution>()}},
+        {"Conv2DBackpropInput",
+         {std::make_shared<opset::ConvolutionBackpropData>(),
+          std::make_shared<opset::Transpose>()}},
+        {"Conv3D",
+         {std::make_shared<opset::Convolution>(),
+          std::make_shared<opset::Transpose>()}},
+        {"Cos", {std::make_shared<opset::Cos>()}},
+        {"Cosh", {std::make_shared<opset::Cosh>()}},
+        {"Cumsum", {std::make_shared<opset::CumSum>()}},
+        {"DepthToSpace", {std::make_shared<opset::DepthToSpace>()}},
+        {"DepthwiseConv2dNative",
+         {std::make_shared<opset::GroupConvolution>()}},
+        {"Equal", {std::make_shared<opset::Equal>()}},
+        {"Exp", {std::make_shared<opset::Exp>()}},
+        {"ExpandDims", {std::make_shared<opset::Unsqueeze>()}},
+        {"Fill", {std::make_shared<opset::Broadcast>()}},
+        {"Floor", {std::make_shared<opset::Floor>()}},
+        {"FloorDiv",
+         {std::make_shared<opset::Divide>(), std::make_shared<opset::Floor>(),
+          std::make_shared<opset::Broadcast>()}},
+        {"FloorMod", {std::make_shared<opset::FloorMod>()}},
+        {"FusedBatchNorm", {std::make_shared<opset::BatchNormInference>()}},
+        {"FusedBatchNormV2",
+         {std::make_shared<opset::BatchNormInference>(),
+          std::make_shared<opset::Transpose>()}},
+        {"FusedBatchNormV3",
+         {std::make_shared<opset::BatchNormInference>(),
+          std::make_shared<opset::Transpose>()}},
+        {"Gather", {std::make_shared<opset::Gather>()}},
+        {"GatherV2", {std::make_shared<opset::Gather>()}},
+        {"_FusedConv2D",
+         {std::make_shared<opset::Convolution>(),
+          std::make_shared<opset::Minimum>(), std::make_shared<opset::Relu>(),
+          std::make_shared<opset::Add>(),
+          std::make_shared<opset::BatchNormInference>()}},
+        {"_FusedMatMul",
+         {std::make_shared<opset::MatMul>(), std::make_shared<opset::Relu>(),
+          std::make_shared<opset::Add>(), std::make_shared<opset::Minimum>()}},
+        {"Greater", {std::make_shared<opset::Greater>()}},
+        {"GreaterEqual", {std::make_shared<opset::GreaterEqual>()}},
+        {"Identity", {}},
+        {"IsFinite",
+         {std::make_shared<opset::NotEqual>(), std::make_shared<opset::Equal>(),
+          std::make_shared<opset::LogicalAnd>()}},
+        {"L2Loss",
+         {std::make_shared<opset::Multiply>(),
+          std::make_shared<opset::ReduceSum>(),
+          std::make_shared<opset::Divide>()}},
+        {"LogSoftmax",
+         {std::make_shared<opset::Exp>(), std::make_shared<opset::ReduceMax>(),
+          std::make_shared<opset::ReduceSum>(),
+          std::make_shared<opset::Subtract>(), std::make_shared<opset::Log>()}},
+        {"Less", {std::make_shared<opset::Less>()}},
+        {"LessEqual", {std::make_shared<opset::LessEqual>()}},
+        {"Log", {std::make_shared<opset::Log>()}},
+        {"Log1p",
+         {std::make_shared<opset::Add>(), std::make_shared<opset::Log>()}},
+        {"LogicalAnd", {std::make_shared<opset::LogicalAnd>()}},
+        {"LogicalNot", {std::make_shared<opset::LogicalNot>()}},
+        {"LogicalOr", {std::make_shared<opset::LogicalOr>()}},
+        {"LRN", {std::make_shared<opset::LRN>()}},
+        {"MatMul", {std::make_shared<opset::MatMul>()}},
+        {"Max", {std::make_shared<opset::ReduceMax>()}},
+        {"Maximum", {std::make_shared<opset::Maximum>()}},
+        {"MaxPool",
+         {std::make_shared<opset::Transpose>(),
+          std::make_shared<opset::MaxPool>()}},
+        {"MaxPool3D",
+         {std::make_shared<opset::Transpose>(),
+          std::make_shared<opset::MaxPool>()}},
+        {"Mean", {std::make_shared<opset::ReduceMean>()}},
+        {"Min", {std::make_shared<opset::ReduceMin>()}},
+        {"Minimum", {std::make_shared<opset::Minimum>()}},
+        {"MirrorPad", {std::make_shared<opset::Pad>()}},
+        {"Mul", {std::make_shared<opset::Multiply>()}},
+        {"Mod", {std::make_shared<opset::Mod>()}},
+        {"Neg", {std::make_shared<opset::Negative>()}},
+        {"NotEqual", {std::make_shared<opset::NotEqual>()}},
+        {"NonMaxSuppressionV2",
+         {std::make_shared<opset::NonMaxSuppression>(),
+          std::make_shared<opset::Unsqueeze>(),
+          std::make_shared<opset::StridedSlice>()}},
+        {"OneHot", {std::make_shared<opset::OneHot>()}},
+        {"Pack",
+         {std::make_shared<opset::Concat>(),
+          std::make_shared<opset::Unsqueeze>()}},
+        {"Pad", {std::make_shared<opset::Pad>()}},
+        {"PadV2", {std::make_shared<opset::Pad>()}},
+        {"Pow", {std::make_shared<opset::Power>()}},
+        {"Prod", {std::make_shared<opset::ReduceProd>()}},
+        {"Range", {std::make_shared<opset::Range>()}},
+        {"Rank", {}},
+        {"RealDiv", {std::make_shared<opset::Divide>()}},
+        {"Reciprocal", {std::make_shared<opset::Power>()}},
+        {"Relu", {std::make_shared<opset::Relu>()}},
+        {"Relu6", {std::make_shared<opset::Clamp>()}},
+        {"Rsqrt", {std::make_shared<opset::Power>()}},
+        {"Select", {std::make_shared<opset::Select>()}},
+        {"SelectV2", {std::make_shared<opset::Select>()}},
+        {"Reshape", {std::make_shared<opset::Reshape>()}},
+        {"Shape", {std::make_shared<opset::ShapeOf>()}},
+        {"Sigmoid", {std::make_shared<opset::Sigmoid>()}},
+        {"Sin", {std::make_shared<opset::Sin>()}},
+        {"Sinh", {std::make_shared<opset::Sinh>()}},
+        {"Size", {}},
+        {"Sign", {std::make_shared<opset::Sign>()}},
+        {"Slice", {std::make_shared<opset::StridedSlice>()}},
+        {"Snapshot", {}},
+        {"Softmax", {std::make_shared<opset::Softmax>()}},
+        {"Softplus", {std::make_shared<opset::SoftPlus>()}},
+        {"SpaceToDepth", {std::make_shared<opset::SpaceToDepth>()}},
+        {"Split", {std::make_shared<opset::Split>()}},
+        {"SplitV", {std::make_shared<opset::VariadicSplit>()}},
+        {"Sqrt", {std::make_shared<opset::Sqrt>()}},
+        {"Square", {std::make_shared<opset::Multiply>()}},
+        {"SquaredDifference", {std::make_shared<opset::SquaredDifference>()}},
+        {"Squeeze", {std::make_shared<opset::Squeeze>()}},
+        {"StridedSlice", {std::make_shared<opset::StridedSlice>()}},
+        {"Sub", {std::make_shared<opset::Subtract>()}},
+        {"Sum", {std::make_shared<opset::ReduceSum>()}},
+        {"Tan", {std::make_shared<opset::Tan>()}},
+        {"Tanh", {std::make_shared<opset::Tanh>()}},
+        {"Tile", {std::make_shared<opset::Tile>()}},
+        {"TopKV2", {std::make_shared<opset::TopK>()}},
+        {"Transpose", {std::make_shared<opset::Transpose>()}},
+        {"Where",
+         {std::make_shared<opset::NonZero>(),
+          std::make_shared<opset::Transpose>()}},
+        {"Xdivy",
+         {std::make_shared<opset::Divide>(), std::make_shared<opset::Equal>(),
+          std::make_shared<opset::Select>()}},
+        {"Unpack", {std::make_shared<opset::StridedSlice>()}},
+        {"ZerosLike", {}},
+        {"NoOp", {}},
+    };
+
+bool Backend::IsSupported(const char* op) const {
+  string op_(op);
+  auto ng_op = TFtoNgraphOpMap.find(op_);
+  if (ng_op == TFtoNgraphOpMap.end()) {
+    NGRAPH_VLOG(0) << "TF Op is not found in the map: " << op;
+    return false;
+  }
+
+  // Loop through the ngraph op list to query
   const auto& opset = ngraph::get_opset5();
-  return opset.contains_op_type(&node);
+  for (auto it = ng_op->second.begin(); it != ng_op->second.end(); it++) {
+    // TODO: check if the given backend/device supports the op. Right now we're
+    // assuming
+    // that the selected backend supports all opset5 ops
+    ngraph::Node& node = **it;
+    if (!opset.contains_op_type(&node)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 }  // namespace ngraph_bridge

--- a/ngraph_bridge/backend.h
+++ b/ngraph_bridge/backend.h
@@ -37,7 +37,7 @@ class Backend {
                                  bool enable_performance_data = false);
 
   bool IsSupported(const char*) const;
-  string& name() { return m_device; }
+  string& Name() { return m_device; }
 
  private:
   string m_device;

--- a/ngraph_bridge/backend.h
+++ b/ngraph_bridge/backend.h
@@ -35,7 +35,9 @@ class Backend {
 
   shared_ptr<Executable> Compile(shared_ptr<ngraph::Function> func,
                                  bool enable_performance_data = false);
+
   bool IsSupported(const ngraph::Node& node) const;
+  string& name() { return m_device; }
 
  private:
   string m_device;

--- a/ngraph_bridge/backend.h
+++ b/ngraph_bridge/backend.h
@@ -36,7 +36,7 @@ class Backend {
   shared_ptr<Executable> Compile(shared_ptr<ngraph::Function> func,
                                  bool enable_performance_data = false);
 
-  bool IsSupported(const ngraph::Node& node) const;
+  bool IsSupported(const char*) const;
   string& name() { return m_device; }
 
  private:

--- a/ngraph_bridge/backend_manager.cc
+++ b/ngraph_bridge/backend_manager.cc
@@ -25,7 +25,6 @@ namespace tensorflow {
 namespace ngraph_bridge {
 
 shared_ptr<Backend> BackendManager::m_backend;
-string BackendManager::m_backend_name;
 mutex BackendManager::m_backend_mutex;
 
 BackendManager::~BackendManager() {
@@ -44,7 +43,6 @@ void BackendManager::SetBackend(const string& backend_name) {
 
   lock_guard<mutex> lock(m_backend_mutex);
   m_backend = backend;
-  m_backend_name = bname;
 }
 
 shared_ptr<Backend> BackendManager::GetBackend() {
@@ -59,20 +57,6 @@ shared_ptr<Backend> BackendManager::GetBackend() {
   }
   lock_guard<mutex> lock(m_backend_mutex);
   return m_backend;
-}
-
-void BackendManager::GetBackendName(string& backend_name) {
-  NGRAPH_VLOG(2) << "BackendManager::GetBackendName()";
-  if (m_backend == nullptr) {
-    try {
-      SetBackend();
-    } catch (const std::exception& e) {
-      NGRAPH_VLOG(0) << "Failed to get backend name: " << e.what();
-      throw runtime_error("Failed to get backend name: " + string(e.what()));
-    }
-  }
-  lock_guard<mutex> lock(m_backend_mutex);
-  backend_name = m_backend_name;
 }
 
 void BackendManager::CreateBackend(shared_ptr<Backend>& backend,

--- a/ngraph_bridge/backend_manager.h
+++ b/ngraph_bridge/backend_manager.h
@@ -23,8 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "tensorflow/core/lib/core/status.h"
-
 #include "backend.h"
 
 using namespace std;
@@ -38,20 +36,19 @@ class BackendManager {
   static vector<string> GetSupportedBackends();
 
   // Set the BackendManager backend ng_backend_name_
-  static Status SetBackend(const string& backend_name = "CPU");
+  static void SetBackend(const string& backend_name = "CPU");
 
   // Returns the currently set backend
   static shared_ptr<Backend> GetBackend();
 
   // Returns the currently set backend's name
-  static Status GetBackendName(string& backend_name);
+  static void GetBackendName(string& backend_name);
 
   ~BackendManager();
 
  private:
   // Creates backend of backend_name type
-  static Status CreateBackend(shared_ptr<Backend>& backend,
-                              string& backend_name);
+  static void CreateBackend(shared_ptr<Backend>& backend, string& backend_name);
 
   static shared_ptr<Backend> m_backend;
   static string m_backend_name;

--- a/ngraph_bridge/backend_manager.h
+++ b/ngraph_bridge/backend_manager.h
@@ -41,9 +41,6 @@ class BackendManager {
   // Returns the currently set backend
   static shared_ptr<Backend> GetBackend();
 
-  // Returns the currently set backend's name
-  static void GetBackendName(string& backend_name);
-
   ~BackendManager();
 
  private:
@@ -51,7 +48,6 @@ class BackendManager {
   static void CreateBackend(shared_ptr<Backend>& backend, string& backend_name);
 
   static shared_ptr<Backend> m_backend;
-  static string m_backend_name;
   static mutex m_backend_mutex;
 };
 

--- a/ngraph_bridge/deassign_clusters.cc
+++ b/ngraph_bridge/deassign_clusters.cc
@@ -32,7 +32,7 @@
 #include "deassign_clusters.h"
 #include "log.h"
 #include "mark_for_clustering.h"
-#include "utils.h"
+#include "tf_utils.h"
 
 using namespace std;
 
@@ -121,7 +121,7 @@ static void MaybeLogPlacement(const Graph* graph) {
 
   // log the ops gets deassigned
   std::cout << "NGTF_SUMMARY: Op_deassigned: ";
-  util::PrintNodeHistogram(deassigned_histogram);
+  tf_utils::PrintNodeHistogram(deassigned_histogram);
 
   for (auto kv : final_cluster_map) {
     int cluster_idx = kv.first;

--- a/ngraph_bridge/encapsulate_clusters.cc
+++ b/ngraph_bridge/encapsulate_clusters.cc
@@ -42,7 +42,7 @@
 #include "log.h"
 #include "mark_for_clustering.h"
 #include "ngraph_builder.h"
-#include "utils.h"
+#include "tf_utils.h"
 #include "version.h"
 
 using namespace std;
@@ -97,7 +97,7 @@ Status EncapsulateClusters(
       TF_RETURN_IF_ERROR(ConvertGraphDefToGraph(
           opts, *ClusterManager::GetClusterGraph(cluster_idx), &g));
 
-      util::DumpTFGraph(&g, cluster_idx, "ngraph_cluster_");
+      tf_utils::DumpTFGraph(&g, cluster_idx, "ngraph_cluster_");
     }
   }
 

--- a/ngraph_bridge/executable.cc
+++ b/ngraph_bridge/executable.cc
@@ -130,10 +130,10 @@ Executable::Executable(shared_ptr<Function> func, string device)
   InferenceEngine::Core ie;
   std::map<string, string> options;
 
-  if (util::DumpAllGraphs()) {
+  if (utils::DumpAllGraphs()) {
     auto& name = m_function->get_friendly_name();
     m_network.serialize(name + ".xml", name + ".bin");
-    util::DumpNGGraph(func, name + "_executable");
+    utils::DumpNGGraph(func, name + "_executable");
     if (m_device == "CPU") {
       options[InferenceEngine::PluginConfigParams::KEY_DUMP_EXEC_GRAPH_AS_DOT] =
           name + "_IE_" + m_device;

--- a/ngraph_bridge/log.h
+++ b/ngraph_bridge/log.h
@@ -18,7 +18,6 @@
 
 #include <sstream>
 #include <string>
-#include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/default/logging.h"
 #include "tensorflow/core/platform/macros.h"
 

--- a/ngraph_bridge/mark_for_clustering.cc
+++ b/ngraph_bridge/mark_for_clustering.cc
@@ -678,7 +678,7 @@ Status MarkForClustering(Graph* graph,
         NGRAPH_VLOG(5) << "TF Op " << node->name() << " of type "
                        << node->type_string()
                        << " is not supported by backend: "
-                       << op_backend->name();
+                       << op_backend->Name();
         break;
       }
 

--- a/ngraph_bridge/mark_for_clustering.cc
+++ b/ngraph_bridge/mark_for_clustering.cc
@@ -170,32 +170,6 @@ static ConfirmationFunction FusedBatchNormConfirmationFunction() {
   return cf;
 };
 
-// Check if op is supported by backend using is_supported API
-Status IsSupportedByBackend(
-    const Node* node, const shared_ptr<Backend> op_backend,
-    const std::map<std::string, std::set<shared_ptr<ngraph::Node>>>&
-        TFtoNgraphOpMap,
-    bool& is_supported) {
-  is_supported = true;
-
-  auto ng_op = TFtoNgraphOpMap.find(node->type_string());
-  if (ng_op == TFtoNgraphOpMap.end()) {
-    return errors::Internal("TF Op is not found in the map: ",
-                            node->type_string());
-  }
-
-  // Loop through the ngraph op list to query
-  for (auto it = ng_op->second.begin(); it != ng_op->second.end(); it++) {
-    // Pass ngraph node to check if backend supports this op
-    auto ret = op_backend->IsSupported(**it);
-    if (!ret) {
-      is_supported = false;
-      return Status::OK();
-    }
-  }
-  return Status::OK();
-}
-
 const std::map<std::string, SetAttributesFunction>& GetAttributeSetters() {
   //
   // A map of op types (e.g. "Add") to set_attribute functions. These can be
@@ -588,192 +562,6 @@ const TypeConstraintMap& GetTypeConstraintMap() {
   return type_constraint_map;
 }
 
-const std::map<std::string, std::set<std::shared_ptr<ngraph::Node>>>&
-GetTFToNgOpMap() {
-  // Constant Op does not have default Constructor
-  // in ngraph, so passing a dummy node
-  auto constant =
-      opset::Constant::create(ngraph::element::f32, ngraph::Shape{}, {2.0f});
-  // Map:: TF ops to NG Ops to track if all the Ngraph ops
-  // are supported by backend
-  // Update this Map if a new TF Op translation is
-  // implemented or a new Ngraph Op has been added
-  static std::map<std::string, std::set<shared_ptr<ngraph::Node>>>
-      TFtoNgraphOpMap{
-          {"Abs", {std::make_shared<opset::Abs>()}},
-          {"Acos", {std::make_shared<opset::Acos>()}},
-          {"Acosh", {std::make_shared<opset::Acosh>()}},
-          {"Add", {std::make_shared<opset::Add>()}},
-          {"AddN", {std::make_shared<opset::Add>()}},
-          {"AddV2", {std::make_shared<opset::Add>()}},
-          {"Any", {std::make_shared<opset::ReduceLogicalOr>(), constant}},
-          {"All", {std::make_shared<opset::ReduceLogicalAnd>(), constant}},
-          {"ArgMax",
-           {std::make_shared<opset::TopK>(), std::make_shared<opset::Squeeze>(),
-            constant}},
-          {"ArgMin",
-           {std::make_shared<opset::TopK>(), std::make_shared<opset::Squeeze>(),
-            constant}},
-          {"Asin", {std::make_shared<opset::Asin>()}},
-          {"Asinh", {std::make_shared<opset::Asinh>()}},
-          {"Atan", {std::make_shared<opset::Atan>()}},
-          {"Atanh", {std::make_shared<opset::Atanh>()}},
-          {"AvgPool", {std::make_shared<opset::AvgPool>()}},
-          {"BiasAdd",
-           {constant, std::make_shared<opset::Add>(),
-            std::make_shared<opset::Reshape>()}},
-          {"Cast", {std::make_shared<opset::Convert>()}},
-          {"Ceil", {std::make_shared<opset::Ceiling>()}},
-          {"ConcatV2", {std::make_shared<opset::Concat>()}},
-          {"Const", {constant}},
-          {"Conv2D",
-           {std::make_shared<opset::Transpose>(),
-            std::make_shared<opset::Convolution>()}},
-          {"Conv2DBackpropInput",
-           {std::make_shared<opset::ConvolutionBackpropData>(),
-            std::make_shared<opset::Transpose>(), constant}},
-          {"Conv3D",
-           {constant, std::make_shared<opset::Convolution>(),
-            std::make_shared<opset::Transpose>()}},
-          {"Cos", {std::make_shared<opset::Cos>()}},
-          {"Cosh", {std::make_shared<opset::Cosh>()}},
-          {"Cumsum", {std::make_shared<opset::CumSum>()}},
-          {"DepthToSpace", {std::make_shared<opset::DepthToSpace>()}},
-          {"DepthwiseConv2dNative",
-           {std::make_shared<opset::GroupConvolution>(), constant}},
-          {"Equal", {std::make_shared<opset::Equal>()}},
-          {"Exp", {std::make_shared<opset::Exp>()}},
-          {"ExpandDims", {std::make_shared<opset::Unsqueeze>()}},
-          {"Fill", {constant, std::make_shared<opset::Broadcast>()}},
-          {"Floor", {std::make_shared<opset::Floor>()}},
-          {"FloorDiv",
-           {std::make_shared<opset::Divide>(), std::make_shared<opset::Floor>(),
-            std::make_shared<opset::Broadcast>()}},
-          {"FloorMod", {std::make_shared<opset::FloorMod>()}},
-          {"FusedBatchNorm", {std::make_shared<opset::BatchNormInference>()}},
-          {"FusedBatchNormV2",
-           {constant, std::make_shared<opset::BatchNormInference>(),
-            std::make_shared<opset::Transpose>()}},
-          {"FusedBatchNormV3",
-           {constant, std::make_shared<opset::BatchNormInference>(),
-            std::make_shared<opset::Transpose>()}},
-          {"Gather", {constant, std::make_shared<opset::Gather>()}},
-          {"GatherV2", {constant, std::make_shared<opset::Gather>()}},
-          {"_FusedConv2D",
-           {std::make_shared<opset::Convolution>(), constant,
-            std::make_shared<opset::Minimum>(), std::make_shared<opset::Relu>(),
-            std::make_shared<opset::Add>(),
-            std::make_shared<opset::BatchNormInference>()}},
-          {"_FusedMatMul",
-           {std::make_shared<opset::MatMul>(), std::make_shared<opset::Relu>(),
-            std::make_shared<opset::Add>(), constant,
-            std::make_shared<opset::Minimum>()}},
-          {"Greater", {std::make_shared<opset::Greater>()}},
-          {"GreaterEqual", {std::make_shared<opset::GreaterEqual>()}},
-          {"Identity", {}},
-          {"IsFinite",
-           {constant, std::make_shared<opset::NotEqual>(),
-            std::make_shared<opset::Equal>(),
-            std::make_shared<opset::LogicalAnd>()}},
-          {"L2Loss",
-           {constant, std::make_shared<opset::Multiply>(),
-            std::make_shared<opset::ReduceSum>(),
-            std::make_shared<opset::Divide>()}},
-          {"LogSoftmax",
-           {constant, std::make_shared<opset::Exp>(),
-            std::make_shared<opset::ReduceMax>(),
-            std::make_shared<opset::ReduceSum>(),
-            std::make_shared<opset::Subtract>(),
-            std::make_shared<opset::Log>()}},
-          {"Less", {std::make_shared<opset::Less>()}},
-          {"LessEqual", {std::make_shared<opset::LessEqual>()}},
-          {"Log", {std::make_shared<opset::Log>()}},
-          {"Log1p",
-           {constant, std::make_shared<opset::Add>(),
-            std::make_shared<opset::Log>()}},
-          {"LogicalAnd", {std::make_shared<opset::LogicalAnd>()}},
-          {"LogicalNot", {std::make_shared<opset::LogicalNot>()}},
-          {"LogicalOr", {std::make_shared<opset::LogicalOr>()}},
-          {"LRN", {std::make_shared<opset::LRN>()}},
-          {"MatMul", {std::make_shared<opset::MatMul>()}},
-          {"Max", {std::make_shared<opset::ReduceMax>(), constant}},
-          {"Maximum", {std::make_shared<opset::Maximum>()}},
-          {"MaxPool",
-           {constant, std::make_shared<opset::Transpose>(),
-            std::make_shared<opset::MaxPool>()}},
-          {"MaxPool3D",
-           {constant, std::make_shared<opset::Transpose>(),
-            std::make_shared<opset::MaxPool>()}},
-          {"Mean", {std::make_shared<opset::ReduceMean>(), constant}},
-          {"Min", {std::make_shared<opset::ReduceMin>(), constant}},
-          {"Minimum", {std::make_shared<opset::Minimum>()}},
-          {"MirrorPad", {constant, std::make_shared<opset::Pad>()}},
-          {"Mul", {std::make_shared<opset::Multiply>()}},
-          {"Mod", {std::make_shared<opset::Mod>()}},
-          {"Neg", {std::make_shared<opset::Negative>()}},
-          {"NotEqual", {std::make_shared<opset::NotEqual>()}},
-          {"NonMaxSuppressionV2",
-           {std::make_shared<opset::NonMaxSuppression>(), constant,
-            std::make_shared<opset::Unsqueeze>(),
-            std::make_shared<opset::StridedSlice>()}},
-          {"OneHot", {std::make_shared<opset::OneHot>(), constant}},
-          {"Pack",
-           {constant, std::make_shared<opset::Concat>(),
-            std::make_shared<opset::Unsqueeze>()}},
-          {"Pad", {constant, std::make_shared<opset::Pad>()}},
-          {"PadV2", {constant, std::make_shared<opset::Pad>()}},
-          {"Pow", {std::make_shared<opset::Power>()}},
-          {"Prod", {std::make_shared<opset::ReduceProd>(), constant}},
-          {"Range", {std::make_shared<opset::Range>()}},
-          {"Rank", {constant}},
-          {"RealDiv", {std::make_shared<opset::Divide>()}},
-          {"Reciprocal", {constant, std::make_shared<opset::Power>()}},
-          {"Relu", {std::make_shared<opset::Relu>()}},
-          {"Relu6", {std::make_shared<opset::Clamp>()}},
-          {"Rsqrt", {constant, std::make_shared<opset::Power>()}},
-          {"Select", {std::make_shared<opset::Select>()}},
-          {"SelectV2", {std::make_shared<opset::Select>()}},
-          {"Reshape", {std::make_shared<opset::Reshape>()}},
-          {"Shape", {std::make_shared<opset::ShapeOf>()}},
-          {"Sigmoid", {std::make_shared<opset::Sigmoid>()}},
-          {"Sin", {std::make_shared<opset::Sin>()}},
-          {"Sinh", {std::make_shared<opset::Sinh>()}},
-          {"Size", {constant}},
-          {"Sign", {std::make_shared<opset::Sign>()}},
-          {"Slice", {constant, std::make_shared<opset::StridedSlice>()}},
-          {"Snapshot", {}},
-          {"Softmax", {std::make_shared<opset::Softmax>()}},
-          {"Softplus", {std::make_shared<opset::SoftPlus>()}},
-          {"SpaceToDepth", {std::make_shared<opset::SpaceToDepth>()}},
-          {"Split", {std::make_shared<opset::Split>(), constant}},
-          {"SplitV", {std::make_shared<opset::VariadicSplit>(), constant}},
-          {"Sqrt", {std::make_shared<opset::Sqrt>()}},
-          {"Square", {std::make_shared<opset::Multiply>()}},
-          {"SquaredDifference", {std::make_shared<opset::SquaredDifference>()}},
-          {"Squeeze", {std::make_shared<opset::Squeeze>(), constant}},
-          {"StridedSlice", {constant, std::make_shared<opset::StridedSlice>()}},
-          {"Sub", {std::make_shared<opset::Subtract>()}},
-          {"Sum", {std::make_shared<opset::ReduceSum>(), constant}},
-          {"Tan", {std::make_shared<opset::Tan>()}},
-          {"Tanh", {std::make_shared<opset::Tanh>()}},
-          {"Tile", {std::make_shared<opset::Tile>()}},
-          {"TopKV2", {std::make_shared<opset::TopK>(), constant}},
-          {"Transpose", {std::make_shared<opset::Transpose>()}},
-          {"Where",
-           {std::make_shared<opset::NonZero>(),
-            std::make_shared<opset::Transpose>()}},
-          {"Xdivy",
-           {constant, std::make_shared<opset::Divide>(),
-            std::make_shared<opset::Equal>(),
-            std::make_shared<opset::Select>()}},
-          {"Unpack", {constant, std::make_shared<opset::StridedSlice>()}},
-          {"ZerosLike", {constant}},
-          {"NoOp", {}},
-      };
-
-  return TFtoNgraphOpMap;
-}
-
 //
 // Main entry point for the marking pass.
 //
@@ -787,9 +575,6 @@ Status MarkForClustering(Graph* graph,
 
   const std::map<std::string, SetAttributesFunction>& set_attributes_map =
       GetAttributeSetters();
-
-  const std::map<std::string, std::set<std::shared_ptr<ngraph::Node>>>&
-      TFtoNgraphOpMap = GetTFToNgOpMap();
 
   //
   // IF YOU ARE ADDING A NEW OP IMPLEMENTATION, YOU MUST ADD A CONFIRMATION
@@ -888,10 +673,7 @@ Status MarkForClustering(Graph* graph,
       }
 
       // Check if op is supported by backend
-      bool is_supported = false;
-      TF_RETURN_IF_ERROR(IsSupportedByBackend(node, op_backend, TFtoNgraphOpMap,
-                                              is_supported));
-
+      bool is_supported = op_backend->IsSupported(node->type_string().c_str());
       if (!is_supported) {
         NGRAPH_VLOG(5) << "TF Op " << node->name() << " of type "
                        << node->type_string()

--- a/ngraph_bridge/mark_for_clustering.cc
+++ b/ngraph_bridge/mark_for_clustering.cc
@@ -893,11 +893,10 @@ Status MarkForClustering(Graph* graph,
                                               is_supported));
 
       if (!is_supported) {
-        string backend;
-        BackendManager::GetBackendName(backend);
         NGRAPH_VLOG(5) << "TF Op " << node->name() << " of type "
                        << node->type_string()
-                       << " is not supported by backend: " << backend;
+                       << " is not supported by backend: "
+                       << op_backend->name();
         break;
       }
 

--- a/ngraph_bridge/mark_for_clustering.cc
+++ b/ngraph_bridge/mark_for_clustering.cc
@@ -18,7 +18,8 @@
 #include "api.h"
 #include "backend_manager.h"
 #include "default_opset.h"
-#include "utils.h"
+#include "log.h"
+#include "tf_utils.h"
 
 using namespace std;
 
@@ -920,11 +921,11 @@ Status MarkForClustering(Graph* graph,
     std::cout << "\n=============New sub-graph logs=============\n";
     // print summary for nodes failed to be marked
     std::cout << "NGTF_SUMMARY: Op_not_supported: ";
-    util::PrintNodeHistogram(no_support_histogram);
+    tf_utils::PrintNodeHistogram(no_support_histogram);
     std::cout << "NGTF_SUMMARY: Op_failed_confirmation: ";
-    util::PrintNodeHistogram(fail_confirmation_histogram);
+    tf_utils::PrintNodeHistogram(fail_confirmation_histogram);
     std::cout << "NGTF_SUMMARY: Op_failed_type_constraint: ";
-    util::PrintNodeHistogram(fail_constraint_histogram);
+    tf_utils::PrintNodeHistogram(fail_constraint_histogram);
   }
 
   for (auto node : nodes_marked_for_clustering) {

--- a/ngraph_bridge/mark_for_clustering.h
+++ b/ngraph_bridge/mark_for_clustering.h
@@ -52,8 +52,5 @@ const TypeConstraintMap& GetTypeConstraintMap();
 using ConfirmationFunction = std::function<Status(Node*, bool*)>;
 const std::map<std::string, ConfirmationFunction>& GetConfirmationMap();
 
-const std::map<std::string, std::set<std::shared_ptr<ngraph::Node>>>&
-GetTFToNgOpMap();
-
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -33,6 +33,7 @@
 #include "ngraph_builder.h"
 #include "ngraph_conversions.h"
 #include "pass/transpose_sinking.h"
+#include "tf_utils.h"
 #include "utils.h"
 
 using tensorflow::int32;

--- a/ngraph_bridge/ngraph_builder.cc
+++ b/ngraph_bridge/ngraph_builder.cc
@@ -315,7 +315,7 @@ static Status GetStaticInputNode(
     const std::vector<const Tensor*>& static_input_map, DataType dt,
     ng::Output<ng::Node>& node_) {
   ng::element::Type type;
-  TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dt, &type));
+  TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dt, &type));
   switch (dt) {
     case DataType::DT_FLOAT: {
       std::vector<float> vec_float;
@@ -483,7 +483,8 @@ static Status MakeConstOp(const Node* op, ng::element::Type et,
   TensorShape const_shape(shape_proto);
 
   ng::Shape ng_shape;
-  TF_RETURN_IF_ERROR(util::TFTensorShapeToNGraphShape(const_shape, &ng_shape));
+  TF_RETURN_IF_ERROR(
+      tf_utils::TFTensorShapeToNGraphShape(const_shape, &ng_shape));
 
   ng_node =
       ConstructNgNode<opset::Constant>(op->name(), et, ng_shape, const_values);
@@ -675,7 +676,7 @@ static Status TranslateArgMinMax(
   TF_RETURN_IF_ERROR(GetNodeAttr(op->attrs(), "output_type", &dtype));
 
   ng::element::Type ng_et;
-  TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dtype, &ng_et));
+  TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dtype, &ng_et));
 
   auto ng_k = ConstructNgNode<opset::Constant>(
       op->name(), ng::element::i64, ng::Shape{}, std::vector<int64>({1}));
@@ -826,7 +827,7 @@ static Status TranslateCastOp(const Node* op, const std::vector<const Tensor*>&,
   TF_RETURN_IF_ERROR(GetNodeAttr(op->attrs(), "DstT", &dtype));
 
   ng::element::Type ng_et;
-  TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dtype, &ng_et));
+  TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dtype, &ng_et));
 
   try {
     SaveNgOp(ng_op_map, op->name(),
@@ -2097,7 +2098,7 @@ static Status TranslateRangeOp(
   DataType step_type = op->input_type(2);
   ng::element::Type out_type;
   TF_RETURN_IF_ERROR(
-      util::TFDataTypeToNGraphElementType(op->output_type(0), &out_type));
+      tf_utils::TFDataTypeToNGraphElementType(op->output_type(0), &out_type));
   ng::Output<ng::Node> start_node, stop_node, step_node;
   TF_RETURN_IF_ERROR(
       GetStaticInputNode(op, 0, static_input_map, start_type, start_node));
@@ -2204,7 +2205,7 @@ static Status TranslateShapeOp(const Node* op,
   TF_RETURN_IF_ERROR(GetNodeAttr(op->attrs(), "out_type", &dtype));
 
   ng::element::Type type;
-  TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dtype, &type));
+  TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dtype, &type));
 
   // default output_type = element::i64
   SaveNgOp(ng_op_map, op->name(),
@@ -2222,7 +2223,7 @@ static Status TranslateSizeOp(const Node* op, const std::vector<const Tensor*>&,
 
   // Size has an attribute to specify output, int32 or int64
   ng::element::Type type;
-  TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dtype, &type));
+  TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dtype, &type));
 
   auto ng_input_shape = ng_input.get_shape();
   int64 result = 1;
@@ -2893,11 +2894,11 @@ Status Builder::TranslateGraph(
     }
 
     ng::element::Type ng_et;
-    TF_RETURN_IF_ERROR(util::TFDataTypeToNGraphElementType(dtype, &ng_et));
+    TF_RETURN_IF_ERROR(tf_utils::TFDataTypeToNGraphElementType(dtype, &ng_et));
 
     ng::Shape ng_shape;
     TF_RETURN_IF_ERROR(
-        util::TFTensorShapeToNGraphShape(inputs[index], &ng_shape));
+        tf_utils::TFTensorShapeToNGraphShape(inputs[index], &ng_shape));
 
     string prov_tag;
     GetNodeAttr(parm->attrs(), "_prov_tag", &prov_tag);
@@ -2977,10 +2978,10 @@ Status Builder::TranslateGraph(
   //
   {
     ngraph::pass::Manager passes;
-    if (util::GetEnv("NGRAPH_TF_CONSTANT_FOLDING") == "1") {
+    if (utils::GetEnv("NGRAPH_TF_CONSTANT_FOLDING") == "1") {
       passes.register_pass<ngraph::pass::ConstantFolding>();
     }
-    if (util::GetEnv("NGRAPH_TF_TRANSPOSE_SINKING") != "0") {
+    if (utils::GetEnv("NGRAPH_TF_TRANSPOSE_SINKING") != "0") {
       passes.register_pass<pass::TransposeSinking>();
     }
     passes.run_passes(ng_function);

--- a/ngraph_bridge/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/ngraph_rewrite_pass.cc
@@ -78,7 +78,7 @@ Status NGraphRewritePass::Rewrite(
 
   // Now Process the Graph
 
-  // // 1. Mark for clustering then, if requested, dump the graphs.
+  // 1. Mark for clustering then, if requested, dump the graphs.
   TF_RETURN_IF_ERROR(MarkForClustering(graph, skip_these_nodes));
   tf_utils::DumpTFGraph(graph, idx, "marked");
 

--- a/ngraph_bridge/ngraph_rewrite_pass.cc
+++ b/ngraph_bridge/ngraph_rewrite_pass.cc
@@ -29,7 +29,7 @@
 #include "log.h"
 #include "mark_for_clustering.h"
 #include "ngraph_rewrite_pass.h"
-#include "utils.h"
+#include "tf_utils.h"
 
 using namespace std;
 
@@ -57,14 +57,14 @@ Status NGraphRewritePass::Rewrite(
   // runs of this pass.
   int idx = FreshIndex();
   // If requested, dump unmarked graphs.
-  util::DumpTFGraph(graph, idx, "unmarked");
+  tf_utils::DumpTFGraph(graph, idx, "unmarked");
 
   // If ngraph is disabled via ngraph_bridge api or NGRAPH_TF_DISABLE is set
   // we will not do anything; all subsequent
   // passes become a no-op.
   bool ngraph_not_enabled =
       (!api::IsEnabled()) || (std::getenv("NGRAPH_TF_DISABLE") != nullptr);
-  bool already_processed = util::IsAlreadyProcessed(graph);
+  bool already_processed = tf_utils::IsAlreadyProcessed(graph);
   if (!already_processed && ngraph_not_enabled) {
     NGRAPH_VLOG(0) << "NGraph is available but disabled.";
   }
@@ -78,17 +78,17 @@ Status NGraphRewritePass::Rewrite(
 
   // Now Process the Graph
 
-  // 1. Mark for clustering then, if requested, dump the graphs.
+  // // 1. Mark for clustering then, if requested, dump the graphs.
   TF_RETURN_IF_ERROR(MarkForClustering(graph, skip_these_nodes));
-  util::DumpTFGraph(graph, idx, "marked");
+  tf_utils::DumpTFGraph(graph, idx, "marked");
 
   // 2. Assign clusters then, if requested, dump the graphs.
   TF_RETURN_IF_ERROR(AssignClusters(graph));
-  util::DumpTFGraph(graph, idx, "clustered");
+  tf_utils::DumpTFGraph(graph, idx, "clustered");
 
   // 3. Deassign trivial clusters then, if requested, dump the graphs.
   TF_RETURN_IF_ERROR(DeassignClusters(graph));
-  util::DumpTFGraph(graph, idx, "declustered");
+  tf_utils::DumpTFGraph(graph, idx, "declustered");
 
   // 4. Encapsulate clusters then, if requested, dump the graphs.
   auto status = EncapsulateClusters(graph, idx, config_map);
@@ -96,7 +96,7 @@ Status NGraphRewritePass::Rewrite(
     return status;
   }
 
-  util::DumpTFGraph(graph, idx, "encapsulated");
+  tf_utils::DumpTFGraph(graph, idx, "encapsulated");
   return Status::OK();
 }
 

--- a/ngraph_bridge/pass/transpose_sinking.cc
+++ b/ngraph_bridge/pass/transpose_sinking.cc
@@ -436,8 +436,8 @@ bool TransposeSinking::run_on_function(shared_ptr<ngraph::Function> f) {
   set<shared_ptr<ngraph::Node>> transposes_to_delete;
   unordered_map<std::string, ngraph::Shape> orig_result_out_shape;
 
-  if (util::DumpAllGraphs()) {
-    util::DumpNGGraph(f, f->get_friendly_name() + "_before_TS");
+  if (utils::DumpAllGraphs()) {
+    utils::DumpNGGraph(f, f->get_friendly_name() + "_before_TS");
   }
 
   // STEP 1 : Sink or Swim transposes away for op clusters
@@ -489,8 +489,8 @@ bool TransposeSinking::run_on_function(shared_ptr<ngraph::Function> f) {
                  orig_result_out_shape[r->get_name()]);
   }
 
-  if (util::DumpAllGraphs()) {
-    util::DumpNGGraph(f, f->get_friendly_name() + "_after_TS");
+  if (utils::DumpAllGraphs()) {
+    utils::DumpNGGraph(f, f->get_friendly_name() + "_after_TS");
   }
   return true;
 }

--- a/ngraph_bridge/tf_utils.cc
+++ b/ngraph_bridge/tf_utils.cc
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright 2017-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include "log.h"
+#include "tf_utils.h"
+#include "utils.h"
+#include "version.h"
+
+using namespace std;
+
+namespace tensorflow {
+namespace ngraph_bridge {
+namespace tf_utils {
+
+template <typename T>
+static void TensorDataToStream(std::ostream& ostream, int64 n_elements,
+                               const char* data) {
+  const T* data_T = reinterpret_cast<const T*>(data);
+  for (size_t i = 0; i < n_elements; i++) {
+    ostream << data_T[i] << ",";
+  }
+}
+
+Status TensorToStream(std::ostream& ostream, const Tensor& tensor) {
+  const char* data = tensor.tensor_data().data();
+  int64 n_elements = tensor.NumElements();
+  switch (tensor.dtype()) {
+    case DT_HALF:
+      TensorDataToStream<Eigen::half>(ostream, n_elements, data);
+      break;
+    case DT_FLOAT:
+      TensorDataToStream<float>(ostream, n_elements, data);
+      break;
+    case DT_DOUBLE:
+      TensorDataToStream<double>(ostream, n_elements, data);
+      break;
+    case DT_UINT32:
+      TensorDataToStream<uint32>(ostream, n_elements, data);
+      break;
+    case DT_INT32:
+      TensorDataToStream<int32>(ostream, n_elements, data);
+      break;
+    case DT_UINT8:
+    case DT_QUINT8:
+      TensorDataToStream<uint8>(ostream, n_elements, data);
+      break;
+    case DT_UINT16:
+    case DT_QUINT16:
+      TensorDataToStream<uint16>(ostream, n_elements, data);
+      break;
+    case DT_INT8:
+    case DT_QINT8:
+      TensorDataToStream<int8>(ostream, n_elements, data);
+      break;
+    case DT_INT16:
+    case DT_QINT16:
+      TensorDataToStream<int16>(ostream, n_elements, data);
+      break;
+    case DT_UINT64:
+      TensorDataToStream<uint64>(ostream, n_elements, data);
+      break;
+    case DT_INT64:
+      TensorDataToStream<int64>(ostream, n_elements, data);
+      break;
+    case DT_BOOL:
+      TensorDataToStream<bool>(ostream, n_elements, data);
+      break;
+    case DT_BFLOAT16:
+      return errors::Internal(
+          "TensorToStream got data type bfloat16. No compatible standard C++ "
+          "data type.");
+      break;
+    default:
+      return errors::Internal("TensorToStream got unsupported data type ",
+                              DataType_Name(tensor.dtype()));
+      break;
+  }
+  return Status::OK();
+}
+
+Status TFDataTypeToNGraphElementType(DataType tf_dt,
+                                     ngraph::element::Type* ng_et) {
+  switch (tf_dt) {
+    case DataType::DT_FLOAT:
+      *ng_et = ngraph::element::f32;
+      break;
+    case DataType::DT_DOUBLE:
+      *ng_et = ngraph::element::f64;
+      break;
+    case DataType::DT_INT32:
+      *ng_et = ngraph::element::i32;
+      break;
+    case DataType::DT_UINT8:
+      *ng_et = ngraph::element::u8;
+      break;
+    case DataType::DT_INT8:
+      *ng_et = ngraph::element::i8;
+      break;
+    case DataType::DT_UINT16:
+      *ng_et = ngraph::element::u16;
+      break;
+    case DataType::DT_INT64:
+      *ng_et = ngraph::element::i64;
+      break;
+    case DataType::DT_UINT32:
+      *ng_et = ngraph::element::u32;
+      break;
+    case DataType::DT_UINT64:
+      *ng_et = ngraph::element::u64;
+      break;
+    case DataType::DT_BOOL:
+      *ng_et = ngraph::element::boolean;
+      break;
+    case DataType::DT_QINT8:
+      *ng_et = ngraph::element::i8;
+      break;
+    case DataType::DT_QUINT8:
+      *ng_et = ngraph::element::u8;
+      break;
+    case DataType::DT_QINT32:
+      *ng_et = ngraph::element::i32;
+      break;
+    case DataType::DT_BFLOAT16:
+      *ng_et = ngraph::element::bf16;
+      break;
+    case DataType::DT_HALF:
+      *ng_et = ngraph::element::f16;
+      break;
+    default:
+      return errors::Unimplemented("Unsupported TensorFlow data type: ",
+                                   DataType_Name(tf_dt));
+  }
+  return Status::OK();
+}
+
+Status TFTensorShapeToNGraphShape(const TensorShape& tf_shape,
+                                  ngraph::Shape* ng_shape) {
+  for (int i = 0; i < tf_shape.dims(); i++) {
+    if (tf_shape.dim_size(i) < 0) {
+      return errors::InvalidArgument(
+          "TensorFlow shape has a negative dimension size");
+    }
+  }
+
+  *ng_shape = ngraph::Shape(tf_shape.dims());
+  for (int i = 0; i < tf_shape.dims(); i++) {
+    (*ng_shape)[i] = tf_shape.dim_size(i);
+  }
+
+  return Status::OK();
+}
+
+void PrintNodeHistogram(const std::unordered_map<string, int>& histogram,
+                        bool sorted) {
+  int histogram_size = histogram.size();
+  if (histogram_size == 0) {
+    std::cout << "None";
+  } else {
+    vector<std::pair<string, int>> vec(begin(histogram), end(histogram));
+    if (sorted) {
+      sort(begin(vec), end(vec),
+           [](const pair<string, int>& a, const pair<string, int>& b) {
+             // descending sort
+             return a.second > b.second;
+           });
+    }
+
+    for (auto node : vec) {
+      bool endelem = node == vec.back();
+      std::cout << " " << node.first << " -> " << node.second
+                << (endelem ? " " : ",");
+    }
+  }
+  std::cout << std::endl;
+}
+
+void DumpTFGraph(tensorflow::Graph* graph, int idx, std::string filename) {
+  if (!utils::DumpAllGraphs()) {
+    return;
+  }
+
+  std::stringstream ss;
+  ss << filename << "_" << std::setfill('0') << std::setw(4) << idx;
+  NGRAPH_VLOG(0) << "Dumping TF graph to " << ss.str() + ".pbtxt";
+
+  GraphDef g_def;
+  graph->ToGraphDef(&g_def);
+
+  string graph_pb_str;
+  protobuf::TextFormat::PrintToString(g_def, &graph_pb_str);
+  std::ofstream ostrm_out(ss.str() + ".pbtxt", std::ios_base::trunc);
+  ostrm_out << graph_pb_str;
+}
+
+bool IsAlreadyProcessed(Graph* g) {
+  // TODO: place a dummy node as a marker
+  // Current method may fail when graph has no encapsulates after first pass
+  for (Node* node : g->nodes()) {
+    if (node->type_string() == "_nGraphEncapsulate") return true;
+  }
+  return false;
+}
+
+}  // namespace tf_utils
+}  // namespace ngraph_bridge
+}  // namespace tensorflow

--- a/ngraph_bridge/tf_utils.cc
+++ b/ngraph_bridge/tf_utils.cc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2017-2020 Intel Corporation
+ * Copyright 2017-2021 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ngraph_bridge/tf_utils.h
+++ b/ngraph_bridge/tf_utils.h
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2017-2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#pragma once
+
+#include <fstream>
+#include <ostream>
+#include <sstream>
+
+#include "tensorflow/core/common_runtime/dma_helper.h"
+#include "tensorflow/core/common_runtime/optimization_registry.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/graph/graph.h"
+#include "tensorflow/core/platform/tensor_coding.h"
+#include "tensorflow/core/util/saved_tensor_slice_util.h"
+
+#include "ngraph/ngraph.hpp"
+
+using namespace std;
+
+namespace tensorflow {
+namespace ngraph_bridge {
+namespace tf_utils {
+
+bool IsAlreadyProcessed(Graph* g);
+
+// Descending sort the map based on the value
+void PrintNodeHistogram(const std::unordered_map<string, int>&,
+                        bool sorted = true);
+
+Status TensorToStream(std::ostream& ostream, const Tensor& tensor);
+
+// Converts a TensorFlow DataType to an nGraph element::Type. Returns
+// errors::Unimplemented if the element type is not supported by nGraph
+// Core. Otherwise returns Status::OK().
+Status TFDataTypeToNGraphElementType(DataType tf_dt,
+                                     ngraph::element::Type* ng_et);
+
+// Converts a TensorFlow TensorShape to an nGraph Shape. Requires that none of
+// the dimension lengths in tf_shape are negative.
+Status TFTensorShapeToNGraphShape(const TensorShape& tf_shape,
+                                  ngraph::Shape* ng_shape);
+
+// Dump TF graphs in .pbtxt format
+void DumpTFGraph(tensorflow::Graph* graph, int idx, string filename_prefix);
+
+}  // namespace tf_utils
+}  // namespace ngraph_bridge
+}  // namespace tensorflow

--- a/ngraph_bridge/tf_utils.h
+++ b/ngraph_bridge/tf_utils.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2017-2020 Intel Corporation
+ * Copyright 2017-2021 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ngraph_bridge/utils.cc
+++ b/ngraph_bridge/utils.cc
@@ -19,16 +19,6 @@
 #include <iostream>
 #include <sstream>
 
-#include "tensorflow/core/common_runtime/dma_helper.h"
-#include "tensorflow/core/common_runtime/optimization_registry.h"
-#include "tensorflow/core/framework/attr_value_util.h"
-#include "tensorflow/core/framework/graph.pb.h"
-#include "tensorflow/core/framework/node_def_util.h"
-#include "tensorflow/core/graph/graph.h"
-#include "tensorflow/core/lib/strings/str_util.h"
-#include "tensorflow/core/platform/default/logging.h"
-#include "tensorflow/core/platform/protobuf.h"
-
 #include "utils.h"
 #include "version.h"
 
@@ -36,169 +26,7 @@ using namespace std;
 
 namespace tensorflow {
 namespace ngraph_bridge {
-namespace util {
-
-template <typename T>
-static void TensorDataToStream(std::ostream& ostream, int64 n_elements,
-                               const char* data) {
-  const T* data_T = reinterpret_cast<const T*>(data);
-  for (size_t i = 0; i < n_elements; i++) {
-    ostream << data_T[i] << ",";
-  }
-}
-
-Status TensorToStream(std::ostream& ostream, const Tensor& tensor) {
-  const char* data = tensor.tensor_data().data();
-  int64 n_elements = tensor.NumElements();
-  switch (tensor.dtype()) {
-    case DT_HALF:
-      TensorDataToStream<Eigen::half>(ostream, n_elements, data);
-      break;
-    case DT_FLOAT:
-      TensorDataToStream<float>(ostream, n_elements, data);
-      break;
-    case DT_DOUBLE:
-      TensorDataToStream<double>(ostream, n_elements, data);
-      break;
-    case DT_UINT32:
-      TensorDataToStream<uint32>(ostream, n_elements, data);
-      break;
-    case DT_INT32:
-      TensorDataToStream<int32>(ostream, n_elements, data);
-      break;
-    case DT_UINT8:
-    case DT_QUINT8:
-      TensorDataToStream<uint8>(ostream, n_elements, data);
-      break;
-    case DT_UINT16:
-    case DT_QUINT16:
-      TensorDataToStream<uint16>(ostream, n_elements, data);
-      break;
-    case DT_INT8:
-    case DT_QINT8:
-      TensorDataToStream<int8>(ostream, n_elements, data);
-      break;
-    case DT_INT16:
-    case DT_QINT16:
-      TensorDataToStream<int16>(ostream, n_elements, data);
-      break;
-    case DT_UINT64:
-      TensorDataToStream<uint64>(ostream, n_elements, data);
-      break;
-    case DT_INT64:
-      TensorDataToStream<int64>(ostream, n_elements, data);
-      break;
-    case DT_BOOL:
-      TensorDataToStream<bool>(ostream, n_elements, data);
-      break;
-    case DT_BFLOAT16:
-      return errors::Internal(
-          "TensorToStream got data type bfloat16. No compatible standard C++ "
-          "data type.");
-      break;
-    default:
-      return errors::Internal("TensorToStream got unsupported data type ",
-                              DataType_Name(tensor.dtype()));
-      break;
-  }
-  return Status::OK();
-}
-
-Status TFDataTypeToNGraphElementType(DataType tf_dt,
-                                     ngraph::element::Type* ng_et) {
-  switch (tf_dt) {
-    case DataType::DT_FLOAT:
-      *ng_et = ngraph::element::f32;
-      break;
-    case DataType::DT_DOUBLE:
-      *ng_et = ngraph::element::f64;
-      break;
-    case DataType::DT_INT32:
-      *ng_et = ngraph::element::i32;
-      break;
-    case DataType::DT_UINT8:
-      *ng_et = ngraph::element::u8;
-      break;
-    case DataType::DT_INT8:
-      *ng_et = ngraph::element::i8;
-      break;
-    case DataType::DT_UINT16:
-      *ng_et = ngraph::element::u16;
-      break;
-    case DataType::DT_INT64:
-      *ng_et = ngraph::element::i64;
-      break;
-    case DataType::DT_UINT32:
-      *ng_et = ngraph::element::u32;
-      break;
-    case DataType::DT_UINT64:
-      *ng_et = ngraph::element::u64;
-      break;
-    case DataType::DT_BOOL:
-      *ng_et = ngraph::element::boolean;
-      break;
-    case DataType::DT_QINT8:
-      *ng_et = ngraph::element::i8;
-      break;
-    case DataType::DT_QUINT8:
-      *ng_et = ngraph::element::u8;
-      break;
-    case DataType::DT_QINT32:
-      *ng_et = ngraph::element::i32;
-      break;
-    case DataType::DT_BFLOAT16:
-      *ng_et = ngraph::element::bf16;
-      break;
-    case DataType::DT_HALF:
-      *ng_et = ngraph::element::f16;
-      break;
-    default:
-      return errors::Unimplemented("Unsupported TensorFlow data type: ",
-                                   DataType_Name(tf_dt));
-  }
-  return Status::OK();
-}
-
-Status TFTensorShapeToNGraphShape(const TensorShape& tf_shape,
-                                  ngraph::Shape* ng_shape) {
-  for (int i = 0; i < tf_shape.dims(); i++) {
-    if (tf_shape.dim_size(i) < 0) {
-      return errors::InvalidArgument(
-          "TensorFlow shape has a negative dimension size");
-    }
-  }
-
-  *ng_shape = ngraph::Shape(tf_shape.dims());
-  for (int i = 0; i < tf_shape.dims(); i++) {
-    (*ng_shape)[i] = tf_shape.dim_size(i);
-  }
-
-  return Status::OK();
-}
-
-void PrintNodeHistogram(const std::unordered_map<string, int>& histogram,
-                        bool sorted) {
-  int histogram_size = histogram.size();
-  if (histogram_size == 0) {
-    std::cout << "None";
-  } else {
-    vector<std::pair<string, int>> vec(begin(histogram), end(histogram));
-    if (sorted) {
-      sort(begin(vec), end(vec),
-           [](const pair<string, int>& a, const pair<string, int>& b) {
-             // descending sort
-             return a.second > b.second;
-           });
-    }
-
-    for (auto node : vec) {
-      bool endelem = node == vec.back();
-      std::cout << " " << node.first << " -> " << node.second
-                << (endelem ? " " : ",");
-    }
-  }
-  std::cout << std::endl;
-}
+namespace utils {
 
 void MemoryProfile(long& vm_usage, long& resident_set) {
   vm_usage = 0;
@@ -223,24 +51,6 @@ void MemoryProfile(long& vm_usage, long& resident_set) {
   }
 }
 
-void DumpTFGraph(tensorflow::Graph* graph, int idx, std::string filename) {
-  if (!DumpAllGraphs()) {
-    return;
-  }
-
-  std::stringstream ss;
-  ss << filename << "_" << std::setfill('0') << std::setw(4) << idx;
-  NGRAPH_VLOG(0) << "Dumping TF graph to " << ss.str() + ".pbtxt";
-
-  GraphDef g_def;
-  graph->ToGraphDef(&g_def);
-
-  string graph_pb_str;
-  protobuf::TextFormat::PrintToString(g_def, &graph_pb_str);
-  std::ofstream ostrm_out(ss.str() + ".pbtxt", std::ios_base::trunc);
-  ostrm_out << graph_pb_str;
-}
-
 void DumpNGGraph(std::shared_ptr<ngraph::Function> function,
                  const string filename) {
   if (!DumpAllGraphs()) {
@@ -257,15 +67,6 @@ void DumpNGGraph(std::shared_ptr<ngraph::Function> function,
 
 bool DumpAllGraphs() { return GetEnv("NGRAPH_TF_DUMP_GRAPHS") == "1"; }
 
-bool IsAlreadyProcessed(Graph* g) {
-  // TODO: place a dummy node as a marker
-  // Current method may fail when graph has no encapsulates after first pass
-  for (Node* node : g->nodes()) {
-    if (node->type_string() == "_nGraphEncapsulate") return true;
-  }
-  return false;
-}
-
 string GetEnv(const char* env) {
   const char* val = std::getenv(env);
   if (val == nullptr) {
@@ -277,6 +78,6 @@ string GetEnv(const char* env) {
 
 void SetEnv(const char* env, const char* val) { setenv(env, val, 1); }
 
-}  // namespace util
+}  // namespace utils
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/utils.h
+++ b/ngraph_bridge/utils.h
@@ -20,13 +20,6 @@
 #include <ostream>
 #include <sstream>
 
-#include "tensorflow/core/common_runtime/dma_helper.h"
-#include "tensorflow/core/common_runtime/optimization_registry.h"
-#include "tensorflow/core/framework/op_kernel.h"
-#include "tensorflow/core/graph/graph.h"
-#include "tensorflow/core/platform/tensor_coding.h"
-#include "tensorflow/core/util/saved_tensor_slice_util.h"
-
 #include "ngraph/chrome_trace.hpp"
 #include "ngraph/ngraph.hpp"
 
@@ -41,34 +34,14 @@ using namespace std;
 
 namespace tensorflow {
 namespace ngraph_bridge {
-namespace util {
-
-bool IsAlreadyProcessed(Graph* g);
-
-// Descending sort the map based on the value
-void PrintNodeHistogram(const std::unordered_map<string, int>&,
-                        bool sorted = true);
-
-Status TensorToStream(std::ostream& ostream, const Tensor& tensor);
-
-// Converts a TensorFlow DataType to an nGraph element::Type. Returns
-// errors::Unimplemented if the element type is not supported by nGraph
-// Core. Otherwise returns Status::OK().
-Status TFDataTypeToNGraphElementType(DataType tf_dt,
-                                     ngraph::element::Type* ng_et);
-
-// Converts a TensorFlow TensorShape to an nGraph Shape. Requires that none of
-// the dimension lengths in tf_shape are negative.
-Status TFTensorShapeToNGraphShape(const TensorShape& tf_shape,
-                                  ngraph::Shape* ng_shape);
+namespace utils {
 
 // Collect the total memory usage through /proc/self/stat
 void MemoryProfile(long&, long&);
 
 // Check if we're supposed to dump graphs
 bool DumpAllGraphs();
-// Dump TF graphs in .pbtxt format
-void DumpTFGraph(tensorflow::Graph* graph, int idx, string filename_prefix);
+
 // Dump nGraph graphs in .dot format
 void DumpNGGraph(std::shared_ptr<ngraph::Function> function,
                  const string filename_prefix);
@@ -79,6 +52,6 @@ string GetEnv(const char* env);
 // Set the environment variable env with val
 void SetEnv(const char* env, const char* val);
 
-}  // namespace util
+}  // namespace utils
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/ngraph_bridge/utils.h
+++ b/ngraph_bridge/utils.h
@@ -16,19 +16,14 @@
 
 #pragma once
 
+#include <unistd.h>
 #include <fstream>
 #include <ostream>
 #include <sstream>
 
-#include "ngraph/chrome_trace.hpp"
 #include "ngraph/ngraph.hpp"
 
 #include "log.h"
-
-// Activates event logging until the end of the current code-block scoping;
-// Automatically writes log data as soon as the the current scope expires.
-#define NG_TRACE(name, category, args) \
-  ngraph::event::Duration dx__ { (name), (category), (args) }
 
 using namespace std;
 

--- a/test/graph_rewrites/backend_manager_test.cc
+++ b/test/graph_rewrites/backend_manager_test.cc
@@ -43,7 +43,7 @@ TEST(BackendManager, SetBackend) {
 
   EXPECT_NO_THROW(BackendManager::SetBackend("CPU"));
   auto backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
   EXPECT_ANY_THROW(BackendManager::SetBackend("temp"));
 
   // Clean Up
@@ -57,30 +57,30 @@ TEST(BackendManager, GetBackend) {
 
   EXPECT_NO_THROW(BackendManager::SetBackend("CPU"));
   auto backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
 
   // expected ERROR
   SetBackendUsingEnvVar("DUMMY");
   backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
 
   // set env variable to ""
   SetBackendUsingEnvVar("");
   backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
 
   // set backend to dummy and env variable to CPU
   // expected CPU
   EXPECT_ANY_THROW(BackendManager::SetBackend("DUMMY"));
   SetBackendUsingEnvVar("CPU");
   backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
 
   // unset env variable
   // expected interpreter
   UnsetBackendUsingEnvVar();
   backend = BackendManager::GetBackend();
-  ASSERT_EQ(backend->name(), "CPU");
+  ASSERT_EQ(backend->Name(), "CPU");
 
   // Clean up
   UnsetBackendUsingEnvVar();

--- a/test/graph_rewrites/backend_manager_test.cc
+++ b/test/graph_rewrites/backend_manager_test.cc
@@ -41,11 +41,10 @@ These tests test the Backend Handling by the bridge.
 TEST(BackendManager, SetBackend) {
   auto env_map = StoreEnv({"NGRAPH_TF_BACKEND"});
 
-  ASSERT_OK(BackendManager::SetBackend("CPU"));
-  string backend;
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
-  ASSERT_NOT_OK(BackendManager::SetBackend("temp"));
+  EXPECT_NO_THROW(BackendManager::SetBackend("CPU"));
+  auto backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
+  EXPECT_ANY_THROW(BackendManager::SetBackend("temp"));
 
   // Clean Up
   // If NGRAPH_TF_BACKEND was set, set it back
@@ -53,40 +52,39 @@ TEST(BackendManager, SetBackend) {
 }
 
 // Test GetBackend API
-TEST(BackendManager, GetBackendName) {
+TEST(BackendManager, GetBackend) {
   auto env_map = StoreEnv({"NGRAPH_TF_BACKEND"});
 
-  ASSERT_OK(BackendManager::SetBackend("CPU"));
-  string backend;
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
+  EXPECT_NO_THROW(BackendManager::SetBackend("CPU"));
+  auto backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
 
   // expected ERROR
   SetBackendUsingEnvVar("DUMMY");
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
+  backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
 
   // set env variable to ""
   SetBackendUsingEnvVar("");
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
+  backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
 
   // set backend to dummy and env variable to CPU
   // expected CPU
-  ASSERT_NOT_OK(BackendManager::SetBackend("DUMMY"));
+  EXPECT_ANY_THROW(BackendManager::SetBackend("DUMMY"));
   SetBackendUsingEnvVar("CPU");
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
+  backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
 
   // unset env variable
   // expected interpreter
   UnsetBackendUsingEnvVar();
-  ASSERT_OK(BackendManager::GetBackendName(backend));
-  ASSERT_EQ(backend, "CPU");
+  backend = BackendManager::GetBackend();
+  ASSERT_EQ(backend->name(), "CPU");
 
   // Clean up
   UnsetBackendUsingEnvVar();
-  ASSERT_OK(BackendManager::SetBackend("CPU"));
+  EXPECT_NO_THROW(BackendManager::SetBackend("CPU"));
   // restore
   // If NGRAPH_TF_BACKEND was set, set it back
   RestoreEnv(env_map);

--- a/test/graph_rewrites/op_by_op_capability_test.cc
+++ b/test/graph_rewrites/op_by_op_capability_test.cc
@@ -60,18 +60,8 @@ TEST(OpByOpCapability, Backend) {
 
   auto constant = ngraph::op::Constant::create(ngraph::element::f32,
                                                ngraph::Shape{}, {2.0f});
-  std::map<std::string, std::set<std::shared_ptr<ngraph::Node>>>
-      TFtoNgraphOpMap{
-          {"Const", {constant}},
-          {"Add", {std::make_shared<opset::Add>()}},
-          {"Mul",
-           {std::make_shared<opset::Multiply>(),
-            std::make_shared<opset::Subtract>()}},
-      };
-
   for (auto node : graph.op_nodes()) {
-    ASSERT_OK(
-        IsSupportedByBackend(node, backend, TFtoNgraphOpMap, is_supported));
+    is_supported = backend->IsSupported(node->type_string().c_str());
     ASSERT_EQ(is_supported, true);
   }
 }

--- a/test/test_thread_safe_queue.cc
+++ b/test/test_thread_safe_queue.cc
@@ -23,7 +23,6 @@
 
 #include "../examples/cpp/thread_safe_queue.h"
 #include "gtest/gtest.h"
-#include "ngraph_bridge/utils.h"
 
 using namespace std;
 
@@ -47,20 +46,15 @@ TEST(ThreadSafeQueue, Simple) {
   // Create two threads
   auto consumer = [&]() {
     while (item_count < 3) {
-      {
-        NG_TRACE("Consumer", "Do Wait", "");
-        while (consumer_do_wait) {
-          // cout << "\033[1;32mConsumer waiting\033[0m\n";
-          absl::SleepFor(absl::Milliseconds(1));
-        }
+      while (consumer_do_wait) {
+        // cout << "\033[1;32mConsumer waiting\033[0m\n";
+        absl::SleepFor(absl::Milliseconds(1));
       }
 
-      {
-        NG_TRACE("Consumer", "Waiting", "");
-        consumer_state = WAITING_FOR_ITEM;
-        // cout << "\033[1;32mWaiting\033[0m" << endl;
-        queue.GetNextAvailable();
-      }
+      consumer_state = WAITING_FOR_ITEM;
+      // cout << "\033[1;32mWaiting\033[0m" << endl;
+      queue.GetNextAvailable();
+
       // cout << "\033[1;32mGot Item: " << item_count << "\033[0m\n";
       item_count++;
       consumer_state = GOT_ITEM;
@@ -73,22 +67,16 @@ TEST(ThreadSafeQueue, Simple) {
   };
 
   std::thread thread0(consumer);
-  {
-    NG_TRACE("Producer", "Waiting", "");
-    // Ensure that the consumer is in waiting state
-    ASSERT_TRUE(consumer_do_wait);
+  // Ensure that the consumer is in waiting state
+  ASSERT_TRUE(consumer_do_wait);
 
-    consumer_do_wait = false;
-    while (consumer_state != WAITING_FOR_ITEM) {
-      absl::SleepFor(absl::Milliseconds(1));
-    }
+  consumer_do_wait = false;
+  while (consumer_state != WAITING_FOR_ITEM) {
+    absl::SleepFor(absl::Milliseconds(1));
   }
 
   // cout << "Now adding an item\n";
-  {
-    NG_TRACE("Producer", "Add", "");
-    queue.Add(nullptr);
-  }
+  queue.Add(nullptr);
   // Wait until the consumer has a chance to move forward
   // cout << "Producer: Waiting for consumer to get ready" << endl;
 
@@ -100,11 +88,8 @@ TEST(ThreadSafeQueue, Simple) {
   // The consumer is now waiting again until consumer_do_wait is signaled
   // Add two more items
   // //cout << "Now adding two items\n";
-  {
-    NG_TRACE("Producer", "Add-2", "");
-    queue.Add(nullptr);
-    queue.Add(nullptr);
-  }
+  queue.Add(nullptr);
+  queue.Add(nullptr);
 
   // cout << "Producer: Waiting for consumer to get ready" << endl;
 

--- a/test/tf_exec.cpp
+++ b/test/tf_exec.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
+#include <thread>
 #include "gtest/gtest.h"
 
 #include "tensorflow/cc/client/client_session.h"


### PR DESCRIPTION
* Remove TF Status/Errors from bridge internal API. Use exceptions instead.
* Split TF and bridge utils into separate files
* Use absl string split and join functions instead of ngraph join and split 
* Move TF op supported check inside backend
* Add `Backend::name()` to get a backend's name
* Remove nGraph tracing